### PR TITLE
Add a CSS icon next to external links to warn users

### DIFF
--- a/docs/custom_theme/assets/stylesheets/custom_theme.css
+++ b/docs/custom_theme/assets/stylesheets/custom_theme.css
@@ -44,3 +44,12 @@
 .md-footer-copyright {
     max-width: 100% !important;
 }
+
+.md-footer a[href^="http"]:after,
+.feedback a[href^="http"]:after,
+.md-content a[href^="http"]:not(.md-content__icon):after {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+  font-size: small;
+  content: " \f360";
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
Add a CSS icon next to external links to warn users. It only does this on content links and footer and feedback links.
The goal is to warn users only. We don't force them to open a new window, it's against good practices and accessibility (see W3C).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
Fixes PAN-2828