### PR TITLE
add maintainers list to doc repos

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,76 @@
+# Maintainers
+
+## Active Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name             | Github           | LFID             |
+| ---------------- | ---------------- | ---------------- |
+| Byron Gravenorst | bgravenorst      | bgravenorst      |
+| Edward Evans     | EdJoJob          | EdJoJob          |
+| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
+| Madeline Murray  | MadelineMurray   | madelinemurray   |
+| Nicolas Massart  | NicolasMassart   | NicolasMassart   |
+| Steven Gregg     | sgregglives      | sagregg          |
+
+## Emeritus Maintainers
+
+None.
+<!--
+| Name | Github | LFID |
+|------|--------|------|
+| null | null   | null |
+-->
+
+## Becoming a Maintainer
+
+Besu doc welcomes community contribution. Community members may progress to become a
+maintainer. To become a maintainer the following steps occur, roughly in order.
+
+- 5 significant changes have been authored by the proposed maintainer and
+  accepted.
+- The proposed maintainer has the sponsorship of at least one other maintainer.
+  - This sponsoring maintainer will create a PR modifying the list of
+    maintainers.
+  - The proposed maintainer accepts the nomination and expresses a willingness
+    to be a long-term (more than 6 month) committer.
+  - This would be a comment in the above PR.
+  - This PR will be communicated in all appropriate communication channels. It
+    should be mentioned in any maintainer/community call. It should also be
+    posted to the appropriate mailing list or chat channels if they exist.
+- Approval by at least 3 current maintainers within two weeks of the proposal or
+  an absolute majority of current maintainers.
+  - These votes will be recorded in the PR modifying the list of maintainers.
+- No veto by another maintainer within two weeks of proposal are recorded.
+  - All vetoes must be accompanied by a public explanation as a comment in the
+    PR for adding this maintainer
+  - The explanation of the veto must be reasonable.
+  - A veto can be retracted, in that case the approval/veto timeframe is reset.
+  - It is bad form to veto, retract, and veto again.
+- The proposed maintainer becomes a maintainer
+  - Either two weeks have passed since the third approval,
+  - Or an absolute majority of maintainers approve.
+  - In either case, no maintainer presents a veto.
+
+## Removing Maintainers
+
+Being a maintainer is not a status symbol or a title to be maintained
+indefinitely. It will occasionally be necessary and appropriate to move a
+maintainer to emeritus status. This can occur in the following situations:
+
+- Resignation of a maintainer.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be no commits or code review comments
+    for one reporting quarter, although this will not be strictly enforced if
+    the maintainer expresses a reasonable intent to continue contributing.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other unspecified circumstances.
+
+Like adding a maintainer the record and governance process for moving a
+maintainer to emeritus status is recorded in the github PR making that change.
+
+Returning to active status from emeritus status uses the same steps as adding a
+new maintainer. Note that the emeritus maintainer already has the 5 required
+significant changes as there is no contribution time horizon for those.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,8 +7,6 @@
 | Name             | Github           | LFID             |
 | ---------------- | ---------------- | ---------------- |
 | Byron Gravenorst | bgravenorst      | bgravenorst      |
-| Edward Evans     | EdJoJob          | EdJoJob          |
-| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
 | Steven Gregg     | sgregglives      | sagregg          |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
As discussed internally by the doc team, here is a proposal to add a Maintainer list on doc as it already exist on Besu code repos.

The initial list of maintainers include only people who contributed significantly to the doc content or doc system and CI and removes developers.

In a second PR in Besu, I will propose to remove technical writers from Besu code repos.
 
NOTE: the list of reviewer requested is copied from https://github.com/hyperledger/besu/pull/83