### PR TITLE
[PAN-3205] Add note that states nat-method can't be used with Docker

### DIFF
--- a/docs/HowTo/Find-and-Connect/Using-UPnP.md
+++ b/docs/HowTo/Find-and-Connect/Using-UPnP.md
@@ -16,8 +16,9 @@ UPnP automatically detects that a node is running in a UPnP environment and prov
 
 Use the [`--nat-method`](../../Reference/CLI/CLI-Syntax.md#nat-method) command line option to enable UPnP.
 
-!!! note
-    Enabling UPnP may slow down node startup, especially on networks without a UPnP gateway device.
+!!! notes
+    * Option `UPNP` might introduce delays during node startup, especially on networks where no UPnP gateway device can be found.
+    * `--nat-method` cannot be used with the [Besu Docker image](../../HowTo/Get-Started/Run-Docker-Image.md).
 
 When UPnP is enabled: 
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -578,19 +578,24 @@ The default is 1000.
 ### nat-method
 
 ```bash tab="Syntax"
---nat-method=<METHOD>
-```
-
-```bash tab="Command Line"
---nat-method=upnp
+--nat-method=UPNP
 ```
 
 ```bash tab="Example Configuration File"
-nat-method="upnp"
+nat-method="UPNP"
 ```
 
-Specifies the method for handling [NAT environments](../../HowTo/Find-and-Connect/Using-UPnP.md). 
-Options are `upnp` and `none`. The default is `none` (that is, NAT functionality is disabled).
+Specify the method for handling [NAT environments](../../HowTo/Find-and-Connect/Using-UPnP.md). Options are: `UPNP` and `NONE`.
+The default is `NONE`, which disables NAT functionality.
+
+!!!tip
+    `UPNP` works well with a typical home or small office environment where a wireless router or modem provides NAT isolation. This should provide
+    automatic detection and port-forwarding. UPnP support is often disabled by default in networking equipment firmware, however, any may need to be
+    explicitly enabled.
+
+!!!notes
+    * Option `UPNP` may introduce delays during node startup, especially on networks where no UPnP gateway device can be found.
+    * `--nat-method` cannot be used on a Docker image.
 
 ### network
 
@@ -773,27 +778,6 @@ p2p-port="1789"
 
 Specifies the P2P listening ports (UDP and TCP).
 The default is 30303. Ports must be [exposed appropriately](../../HowTo/Find-and-Connect/Configuring-Ports.md).
-
-### nat-method
-
-```bash tab="Syntax"
---nat-method=UPNP
-```
-
-```bash tab="Example Configuration File"
-nat-method="UPNP"
-```
-
-Specify the method for handling NAT environments. Options are: `UPNP` and `NONE`.
-The default is `NONE`, which disables NAT functionality.
-
-!!!tip
-    `UPNP` works well with a typical home or small office environment where a wireless router or modem provides NAT isolation. This should provide
-    automatic detection and port-forwarding. UPnP support is often disabled by default in networking equipment firmware, however, any may need to be
-    explicitly enabled.
-
-!!!note
-    Option `UPNP` may introduce delays during node startup, especially on networks where no UPnP gateway device can be found.
 
 ### permissions-accounts-config-file-enabled
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -589,13 +589,11 @@ Specify the method for handling [NAT environments](../../HowTo/Find-and-Connect/
 The default is `NONE`, which disables NAT functionality.
 
 !!!tip
-    `UPNP` works well with a typical home or small office environment where a wireless router or modem provides NAT isolation. This should provide
-    automatic detection and port-forwarding. UPnP support is often disabled by default in networking equipment firmware, however, any may need to be
-    explicitly enabled.
+    UPnP support is often disabled by default in networking firmware. If disabled by default, explicitly enable UPnP support.
 
 !!!notes
-    * Option `UPNP` may introduce delays during node startup, especially on networks where no UPnP gateway device can be found.
-    * `--nat-method` cannot be used on a Docker image.
+    * Option `UPNP` might introduce delays during node startup, especially on networks where no UPnP gateway device can be found.
+    * `--nat-method` cannot be used with the [Besu Docker image](../../HowTo/Get-Started/Run-Docker-Image.md).
 
 ### network
 


### PR DESCRIPTION
Signed-off-by: Steven Gregg <steven.gregg@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
`nat-method` currently can't be used on a Docker image, so a note was added.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
PAN-3205