### PR TITLE
[PAN-3276] Fix typo in title within Configure High Availability of APIs documentation

### DIFF
--- a/docs/HowTo/Configure/Configure-HA/High-Availability.md
+++ b/docs/HowTo/Configure/Configure-HA/High-Availability.md
@@ -1,7 +1,7 @@
 description: Hyperledger Besu high availability 
 <!--- END of page meta data -->
 
-# High Availability of JSON-RPC and RPC Rub/Sub APIs
+# High Availability of JSON-RPC and RPC Pub/Sub APIs
 
 To enable high availability to the [RPC Pub/Sub API over WebSockets](../../Interact/APIs/RPC-PubSub.md) 
 or the [JSON-RPC API](../../Interact/APIs/Using-JSON-RPC-API.md) run and synchronize multiple Hyperledger Besu 


### PR DESCRIPTION
 Signed-off-by: Mohamed Abdulaziz <mo@blok-z.com>

## PR description

There was a typo in the title within the following link: https://besu.hyperledger.org/en/latest/HowTo/Configure/Configure-HA/High-Availability/

The mistake is shown in bold below:
"High Availability of JSON-RPC and RPC **Rub/Sub** APIs" 

Fixed version:
"High Availability of JSON-RPC and RPC **Pub/Sub** APIs" 

## Fixed Issue
Fixes PAN-3276
