### PR TITLE
[PAN-3277] Fix typo in Besu Client Library documentation

### DIFF
--- a/MKDOCS-MARKDOWN-GUIDE.md
+++ b/MKDOCS-MARKDOWN-GUIDE.md
@@ -413,7 +413,7 @@ Example:
 ```` 
 
 Pygment is the implementation for this extension, refer to Pygment website for a 
-[list of the supported languages](http://pygments.org/languages/).
+[list of the supported languages](https://pygments.org/languages.html).
 
 
 

--- a/docs/HowTo/Deploy/Lite-Network-Monitor.md
+++ b/docs/HowTo/Deploy/Lite-Network-Monitor.md
@@ -10,7 +10,7 @@ about the network and nodes.
 EthStats Lite supports in-memory persistence or using Redis to persist a fixed number of blocks
 (by default, 3000). 
 
-You can also use a full online version of EthStats for the [Ethereum MainNet](https://ethstats.io).
+You can also use a full online version of EthStats for the [Ethereum MainNet](https://ethstats.io/).
 
 !!! note 
     The EthStats Lite is an [Alethio product](https://company.aleth.io/developers).

--- a/docs/HowTo/Interact/Client-Libraries/eeajs.md
+++ b/docs/HowTo/Interact/Client-Libraries/eeajs.md
@@ -22,7 +22,7 @@ npm install web3-eea
 
 ## Initialize EEA Client
 
-Initilize your EEA client where:
+Initialize your EEA client where:
 
 * `<JSON-RPC HTTP endpoint>` is the JSON-RPC HTTP endpoint of your Hyperledger Besu node. Specified by the
 [`--rpc-http-host`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-host) and [`--rpc-http-port`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-port)


### PR DESCRIPTION
Signed-off-by: Mohamed Abdulaziz <mo@blok-z.com>

## PR description

"**Initilize** your EEA client where:"

Should be

"**Initialize** your EEA client where:"

See: https://besu.hyperledger.org/en/latest/HowTo/Interact/Client-Libraries/eeajs/

## Fixed Issue
Fixes PAN-3277
