### PR TITLE
[BP-13] Add public-key export-address to info about RLP encoding

### DIFF
--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -71,7 +71,7 @@ to generate the `extraData` RLP string to include in the genesis file.
     besu rlp encode --from=toEncode.json
     ```    
 
-Where the `toEncode.json` file contains a list of the initial validators in ascending order. 
+Where the `toEncode.json` file contains a list of the initial validators in ascending order. Use the Besu subcommand [`public-key export-address`](../../../Reference/CLI/CLI-Subcommands.md#export-address) to write the address of a validator to the `toEncode.json` file. Modify the file to conform to JSON input format.
 
 !!! example "One Initial Validator"
     ```json

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -71,9 +71,9 @@ to generate the `extraData` RLP string to include in the genesis file.
     besu rlp encode --from=toEncode.json
     ```    
 
-Where the `toEncode.json` file contains a list of the initial validators in ascending order. Use the Besu subcommand [`public-key export-address`](../../../Reference/CLI/CLI-Subcommands.md#export-address) to write the address of a validator and copy it to the `toEncode.json` file. For example:
+Where the `toEncode.json` file contains a list of the initial validators in ascending order. Use the Besu subcommand [`public-key export-address`](../../../Reference/CLI/CLI-Subcommands.md#export-address) to write the validator address and copy it to the `toEncode.json` file. For example:
 
-!!! example "One Initial Validator"
+!!! example "One Initial Validator in `toEncode.json` file"
     ```json
     [
      "9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb"

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -71,7 +71,7 @@ to generate the `extraData` RLP string to include in the genesis file.
     besu rlp encode --from=toEncode.json
     ```    
 
-Where the `toEncode.json` file contains a list of the initial validators in ascending order. Use the Besu subcommand [`public-key export-address`](../../../Reference/CLI/CLI-Subcommands.md#export-address) to write the address of a validator to the `toEncode.json` file. Modify the file to conform to JSON input format.
+Where the `toEncode.json` file contains a list of the initial validators in ascending order. Use the Besu subcommand [`public-key export-address`](../../../Reference/CLI/CLI-Subcommands.md#export-address) to write the address of a validator and copy it to the `toEncode.json` file. For example:
 
 !!! example "One Initial Validator"
     ```json
@@ -80,7 +80,7 @@ Where the `toEncode.json` file contains a list of the initial validators in asce
     ]
     ``` 
 
-Copy the RLP encoded data to the `extraData` in the genesis file. 
+Copy the RLP encoded data to the `extraData` property in the genesis file. 
 
 ### Block Time 
 

--- a/docs/Tutorials/Private-Network/Create-IBFT-Network.md
+++ b/docs/Tutorials/Private-Network/Create-IBFT-Network.md
@@ -1,8 +1,7 @@
 description: Hyperledger Besu IBFT 2.0 Proof-of-Authority (PoA) private network tutorial 
 <!--- END of page meta data -->
 
-*[Byzantine fault tolerant]: Ability to function correctly and reach consensus despite nodes failing
-or propagating incorrect information to peers.
+*[Byzantine fault tolerant]: Ability to function correctly and reach consensus despite nodes failing or propagating incorrect information to peers.
 
 # Creating a Private Network using IBFT 2.0 (Proof of Authority) Consensus Protocol
 


### PR DESCRIPTION
Signed-off-by: Steven Gregg <steven.gregg@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
Explain how to use `public-key export-address` to write addresses of validators to the `toEncode.json` file.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
BP-13