### PR TITLE
[BESU-114] Fix duplicated content

### DIFF
--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -13,9 +13,6 @@ Create and send [private transactions](../../Concepts/Privacy/Privacy-Overview.m
 All private transaction participants must be online for a private transaction to be successfully distributed. If any 
 participants are offline when the private transaction is submitted, the transaction is not attempted and must be resubmitted.
 
-All private transaction participants must be online for a private transaction to be successfully distributed. 
-If any participants are offline when the private transaction is submitted, the transaction is not attempted and must be resubmitted.
-
 !!! note
     Private transactions either deploy contracts or call contract functions. 
     Ether transfer transactions cannot be private. 


### PR DESCRIPTION
Signed-off-by: Mohamed Abdulaziz <mo@blok-z.com>

## PR description
I removed the duplicated text "All private transaction participants must be online for a private transaction to be successfully distributed. If any participants are offline when the private transaction is submitted, the transaction is not attempted and must be resubmitted." 

See: http://besu.hyperledger.org/en/latest/HowTo/Send-Transactions/Creating-Sending-Private-Transactions
## Fixed Issue(s)
Fixes BESU-114

See: https://jira.hyperledger.org/browse/BESU-114

