### PR TITLE
Fixed old Jira links + readme typo + added DCO wiki link  (fixes #149)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,12 @@ open a new issue and include a link to the original issue in the body of your ne
 #### Before Submitting A Bug Report
 * **Confirm the problem** clear the cache of your browser and check if the issue is still there. You
 can also disable all your browser plugins and see if the bug still happens.
-* **Perform a [cursory search of project documentation issues](https://pegasys1.atlassian.net/issues/?jql=project%20%3D%20PAN%20AND%20labels%20%3D%20documentation%20order%20by%20created%20DESC** 
+* **Perform a [cursory search of project documentation issues](https://jira.hyperledger.org/rowse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC) 
 to see if the problem has already been reported. If it has **and the issue is still open**, add a comment 
 to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?
-Bugs are tracked as [Jira issues](https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10000).  
+Bugs are tracked as [Jira issues](https://jira.hyperledger.org/browse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC).  
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -103,7 +103,7 @@ When you are creating an enhancement suggestion, please
 
 #### Before Submitting An Enhancement Suggestion
 
-* **Perform a [cursory search of project issues](https://pegasys1.atlassian.net/browse/PAN-2502?jql=project%20%3D%20PAN)** 
+* **Perform a [cursory search of project issues](https://jira.hyperledger.org/browse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)** 
 to see if the problem has already been reported. If it has **and the issue is still open**, add a comment 
 to the existing issue instead of opening a new one.
 
@@ -127,7 +127,7 @@ code snippets.
 * **What Plugins/Extensions & Version have you installed and enabled in your browser?**
 
 ### Your First Contribution
-Start by looking through the 'good first issue' and 'help wanted' labeled issues on the [Jira dashboard](https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10000):
+Start by looking through the 'good first issue' and 'help wanted' labeled issues on the [Jira dashboard](https://jira.hyperledger.org/browse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC):
 * [Good First Issue][search-label-good-first-issue] - issues which should only require a few lines of code or documentation, 
 and a test or two.
 * [Help wanted issues][search-label-help-wanted] - issues which are a bit more involved than `good first issue` issues.
@@ -157,7 +157,7 @@ another part of the doc.
     explained in the [MkDocs And Markdown Guide](MKDOCS-MARKDOWN-GUIDE.md#preview-the-documentation). 
 1. **Push your changes** to your remote fork (usually labeled as `origin`).
 1. **Create a pull-request** (PR) on the Besu doc repository. If the PR addresses an existing Jira issue, 
-include the issue number in the PR title in square brackets (for example, `[PAN-1234]`). 
+include the issue number in the PR title in square brackets (for example, `[BESU-1234]`). 
 1. **Add labels** to identify the type of your PR. _For example, if your PR fixes a bug, add the "bug" label._
 1. If the PR address an existing Jira issue, comment in the Jira issue with the PR number. 
 1. **Ensure your changes are reviewed**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ open a new issue and include a link to the original issue in the body of your ne
 #### Before Submitting A Bug Report
 * **Confirm the problem** clear the cache of your browser and check if the issue is still there. You
 can also disable all your browser plugins and see if the bug still happens.
-* **Perform a [cursory search of project documentation issues](https://jira.hyperledger.org/rowse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC) 
+* **Perform a [cursory search of project documentation issues](https://jira.hyperledger.org/browse/BESU-122?jql=project%20%3D%20BESU%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC) 
 to see if the problem has already been reported. If it has **and the issue is still open**, add a comment 
 to the existing issue instead of opening a new one.
 

--- a/DCO.md
+++ b/DCO.md
@@ -5,5 +5,6 @@ As per section 13.a of the [Hyperledger Charter](https://www.hyperledger.org/abo
 
 The sign off needs to be using your legal name, not a pseudonym.  Git has a built-in mechanism to allow this with the `-s` or `--signoff` argument to `git commit` command, providing your `user.name` and `user.email` have been setup correctly.
 
+For more information, [the Besu wiki](https://wiki.hyperledger.org/pages/viewpage.action?pageId=24772914) contains more details about DCO.
 If you have any questions, you can reach us on [Besu chat].
 [Besu chat]: https://chat.hyperledger.org/channel/besu

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Hyperledger Besu documentation
+# Hyperledger Besu documentation
 
 [Hyperledger Besu](https://github.com/hyperledger/besu/) is a Hyperledger enterprise-grade Java-based,
 Apache 2.0 licensed Ethereum client.


### PR DESCRIPTION
 (fixes #149)

## PR description
- Replaces old Pantheon Jira links with current Besu Jira. 
- Adds link on DCO file to HL Besu wiki DCO page.
- small typo on readme markdown