### PR TITLE
Changed truffle hdwallet-provider string to reflect structure of late…

### DIFF
--- a/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
+++ b/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
@@ -349,7 +349,7 @@ Modify the `truffle-config.js` file in the `pet-shop-tutorial` directory to add 
 code with placeholders to change as directed below:
 
 ```javascript
-const PrivateKeyProvider = require("truffle-hdwallet-provider");
+const PrivateKeyProvider = require("@truffle/hdwallet-provider");
 const privateKey = "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";
 
 module.exports = {


### PR DESCRIPTION
…st version of truffle repo.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
Using the string in the prior example keeps throwing 'could not find hdwallet-provider package' errors.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
