### PR TITLE
update issue tool url

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,5 +19,5 @@ Be sure to set the “Security Level” to “Security issue”.
 
 The process by which the Hyperledger Security Team handles security bugs
 is documented further in our
-[Defect Response](https://wiki.hyperledger.org/display/HYP/Defect+Response)
+[Defect Response](https://wiki.hyperledger.org/display/SEC/Defect+Response)
 page on our [wiki](https://wiki.hyperledger.org).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,4 @@ The other way is to file a confidential security bug in our
 Be sure to set the “Security Level” to “Security issue”.
 
 The process by which the Hyperledger Security Team handles security bugs
-is documented further in our
-[Defect Response](https://wiki.hyperledger.org/display/SEC/Defect+Response)
-page on our [wiki](https://wiki.hyperledger.org).
+is documented further in [Hyperledger defect response wiki page](https://wiki.hyperledger.org/display/SEC/Defect+Response).

--- a/docs/Reference/Responsible-Disclosure.md
+++ b/docs/Reference/Responsible-Disclosure.md
@@ -8,4 +8,4 @@ there may still be vulnerabilities present.
 If you discover a vulnerability, we want to know about it so we can take steps to address it as 
 quickly as possible. We would like to ask you to help us better protect our clients and our systems.
  
-Please follow the process explained at https://wiki.hyperledger.org/display/HYP/Defect+Response
+Please follow the process explained on [Hyperledger defect response wiki page](https://wiki.hyperledger.org/display/SEC/Defect+Response)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ extra:
     chat: https://chat.hyperledger.org/channel/besu
     email: besu@lists.hyperledger.org
     website: https://www.hyperledger.org/projects/besu
-    issues: https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10000
+    issues: https://jira.hyperledger.org/projects/BESU/issues
   google:
     site_verification: 'sGzYdFR_AYDRtsC-SNxMRwjellnfTgs5ZA0q7GIM5j0'
     tag_manager: 'GTM-TS3WLJM'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu-docs/blob/master/CONTRIBUTING.md -->

## PR description
- Small change just to update issue tool url to use HLF Jira instead of Pegasys one.
- Updated security page URL that was moved to HLF wiki instead of Besu one.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
none, just a quick URL fix.