### PR TITLE
add an info pass for md linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,20 @@ jobs:
           command: |
             gem install mdl
       - run:
+          shell: /bin/bash #this is a non breaking command so it will always return success
+          name: Run Markdownlint info checks
+          command: |
+            mdl --ignore-front-matter --style ./CI/markdownlint/info_style.rb . | tee ./markdownlint_info.out
+      - run:
           name: Run Markdownlint
           command: |
             mdl --ignore-front-matter --style ./CI/markdownlint/style.rb . | tee ./markdownlint.out
       - store_artifacts:
           path: ./markdownlint.out
           destination: ./markdownlint.out
+      - store_artifacts:
+          path: ./markdownlint_info.out
+          destination: ./markdownlint_info.out
 
 workflows:
   version: 2

--- a/CI/markdownlint/info_style.rb
+++ b/CI/markdownlint/info_style.rb
@@ -1,0 +1,1 @@
+rule 'line-length', :line_length=>100, :code_blocks=>false, :tables=> false

--- a/CI/markdownlint/style.rb
+++ b/CI/markdownlint/style.rb
@@ -1,8 +1,8 @@
 all
 
 rule "no-duplicate-header", :allow_different_nesting => true
-rule 'line-length', :line_length=>100, :code_blocks=>false, :tables=> false
 rule 'no-trailing-punctuation', :punctuation=>'.,;:!'
 
 exclude_rule 'no-bare-urls'
 exclude_rule 'code-block-style'
+exclude_rule 'line-length'


### PR DESCRIPTION
## PR description

Adding an info pass that's not breaking the build

Line length check is now only in the info pass as we want them not to break the build.

The breaking checks are on another run in the same job
Two artefacts are now produced by the CI job: markdownlint.out and markdownlint_info.out