### PR TITLE
fix indent rule and add comments in style files

### DIFF
--- a/CI/markdownlint/info_style.rb
+++ b/CI/markdownlint/info_style.rb
@@ -1,1 +1,6 @@
+# See https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md for doc
+# on creating and modifying this style file
+# rules are named by their aliases here for clarity, not their code.
+# But for instance, line-length = MD013
+
 rule 'line-length', :line_length=>100, :code_blocks=>false, :tables=> false

--- a/CI/markdownlint/style.rb
+++ b/CI/markdownlint/style.rb
@@ -1,7 +1,12 @@
+# See https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md for doc
+# on creating and modifying this style file
+# rules are named by their aliases here for clarity, not their code.
+# But for instance, ul-indent = MD007
 all
 
 rule "no-duplicate-header", :allow_different_nesting => true
 rule 'no-trailing-punctuation', :punctuation=>'.,;:!'
+rule 'ul-indent', :indent=> 4
 
 exclude_rule 'no-bare-urls'
 exclude_rule 'code-block-style'


### PR DESCRIPTION
## PR description

due to issue in #195 it seems that indent for nested sub lists requires 4 spaces with mkdocs
so the default rule is failing.

This PR updates the rule to 4 spaces
It also adds comments in the style files to help contributors who would like to edit it.