### PR TITLE
New section on concurrent private transactions

### DIFF
--- a/docs/Concepts/Privacy/Private-Transactions.md
+++ b/docs/Concepts/Privacy/Private-Transactions.md
@@ -35,28 +35,28 @@ keys of the Orion nodes sending and receiving the transaction.
 
     The mapping of Besu node addresses to Orion node public keys is off-chain. That is, the sender
     of a private transaction must know the Orion node public key of the recipient.
-    
-## Nonces 
+
+## Nonces
 
 [Private transaction processing](../../Concepts/Privacy/Private-Transaction-Processing.md) involves
-two transactions, the private transaction distributed to involved participants and the 
-[privacy marker transaction] included on the public blockchain. Each each of these transactions has 
+two transactions, the private transaction distributed to involved participants and the
+[privacy marker transaction] included on the public blockchain. Each each of these transactions has
 its own nonce.
 
 ### Private transaction nonce
 
 Besu maintains separate private states for each
-[privacy group](../../Concepts/Privacy/Privacy-Groups.md). The private transaction nonce for an 
-account is specific to the privacy group. That is, the nonce for account A for privacy group ABC is 
-different to the nonce for account A for privacy group AB. 
+[privacy group](../../Concepts/Privacy/Privacy-Groups.md). The private transaction nonce for an
+account is specific to the privacy group. That is, the nonce for account A for privacy group ABC is
+different to the nonce for account A for privacy group AB.
 
 !!! note
     If sending more than one transaction for mining in the same block (that is, you are not waiting
     for the transaction receipt), you must calculate the private transaction nonce outside Besu.
 
-### Privacy marker transaction nonce 
+### Privacy marker transaction nonce
 
-The nonce for the [privacy marker transaction] is the public nonce for the account. 
+The nonce for the [privacy marker transaction] is the public nonce for the account.
 
 <!-- links ---->
 

--- a/docs/Concepts/Privacy/Private-Transactions.md
+++ b/docs/Concepts/Privacy/Private-Transactions.md
@@ -35,3 +35,30 @@ keys of the Orion nodes sending and receiving the transaction.
 
     The mapping of Besu node addresses to Orion node public keys is off-chain. That is, the sender
     of a private transaction must know the Orion node public key of the recipient.
+    
+## Nonces 
+
+[Private transaction processing](../../Concepts/Privacy/Private-Transaction-Processing.md) involves
+two transactions, the private transaction distributed to involved participants and the 
+[privacy marker transaction] included on the public blockchain. Each each of these transactions has 
+its own nonce.
+
+### Private transaction nonce
+
+Besu maintains separate private states for each
+[privacy group](../../Concepts/Privacy/Privacy-Groups.md). The private transaction nonce for an 
+account is specific to the privacy group. That is, the nonce for account A for privacy group ABC is 
+different to the nonce for account A for privacy group AB. 
+
+!!! note
+    If sending more than one transaction for mining in the same block (that is, you are not waiting
+    for the transaction receipt), you must calculate the private transaction nonce outside Besu.
+
+### Privacy marker transaction nonce 
+
+The nonce for the [privacy marker transaction] is the public nonce for the account. 
+
+<!-- links ---->
+
+[privacy marker transaction]: ../../Concepts/Privacy/Private-Transaction-Processing.md
+

--- a/docs/HowTo/Send-Transactions/Concurrent-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Concurrent-Private-Transactions.md
@@ -1,0 +1,23 @@
+---
+description: Creating and sending concurrent private transactions with Hyperledger Besu
+---
+
+# Sending concurrent private transactions
+
+Private transaction processing involves two transactions, the private transaction and the [privacy marker transaction]. 
+The private transaction and the [privacy marker transaction] each have their [own nonce].
+
+If your private transaction rate requires sending private transactions without waiting for the previous
+private transaction to be mined, you must use [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction) 
+instead of [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction). When 
+using [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction) 
+you create and send the privacy marker transaction yourself rather than [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction) 
+handling the privacy marker transaction. 
+
+The [web3js-eea library](https://github.com/PegaSysEng/web3js-eea/blob/master/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js)
+includes an example of how to send concurrent private transactions.
+
+<!-- links ---->
+
+[privacy marker transaction]: ../../Concepts/Privacy/Private-Transaction-Processing.md
+[own nonce]: ../../Concepts/Privacy/Private-Transactions.md#nonces

--- a/docs/HowTo/Send-Transactions/Concurrent-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Concurrent-Private-Transactions.md
@@ -4,15 +4,15 @@ description: Creating and sending concurrent private transactions with Hyperledg
 
 # Sending concurrent private transactions
 
-Private transaction processing involves two transactions, the private transaction and the [privacy marker transaction]. 
+Private transaction processing involves two transactions, the private transaction and the [privacy marker transaction].
 The private transaction and the [privacy marker transaction] each have their [own nonce].
 
 If your private transaction rate requires sending private transactions without waiting for the previous
-private transaction to be mined, you must use [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction) 
-instead of [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction). When 
-using [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction) 
-you create and send the privacy marker transaction yourself rather than [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction) 
-handling the privacy marker transaction. 
+private transaction to be mined, you must use [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction)
+instead of [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction). When
+using [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction)
+you create and send the privacy marker transaction yourself rather than [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction)
+handling the privacy marker transaction.
 
 The [web3js-eea library](https://github.com/PegaSysEng/web3js-eea/blob/master/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js)
 includes an example of how to send concurrent private transactions.

--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -56,7 +56,8 @@ By using the [public Ethereum transaction](Transactions.md),
 [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction), you are signing
 and submitting the
 [privacy marker transaction] yourself instead of having it signed by the Besu node, giving you
-greater control over the [privacy marker transaction].
+greater control over the [privacy marker transaction]. For example, when sending
+[concurrent private transactions](#concurrent_private_transactions).
 
 !!! warning
 
@@ -174,6 +175,26 @@ private transactions to create a contract.
     The `example` directory in the
     [web3js-eea client library](../Interact/Client-Libraries/web3js-eea.md) contains examples of
     signing and encoding private transactions.
+
+## Concurrent private transactions
+
+As outlined in [Private transaction nonces](#private-transaction-nonces), private transaction
+processing involves two transactions, the private transaction and the [privacy marker transaction],
+with each transaction having its own nonce.
+
+!!! warning
+
+    If you use [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction) to
+    send concurrent private transactions, situations can occur where the nonce for some or all of
+    the privacy marker transactions are incorrect, causing some or all of the private transactions
+    to fail.
+
+As a workaround for this issue, use
+[`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction),
+and [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction) to send
+concurrent private transactions. For an example in the
+[web3js-eea library](https://github.com/PegaSysEng/web3js-eea), see
+[`concurrentPrivateTransactions.js`](https://github.com/PegaSysEng/web3js-eea/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js).
 
 <!-- links ---->
 

--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -31,11 +31,11 @@ private transaction to the participating nodes, and signs and submits the
 !!! note
     If sending more than one transaction for mining in the same block (that is, you are not waiting
     for the transaction receipt), you must calculate the private transaction nonce outside Besu.
-    
+
     Use
     [`priv_getTransactionCount`](../../Reference/API-Methods.md#priv_gettransactioncount) or
     [`priv_getEeaTransactionCount`](../../Reference/API-Methods.md#priv_geteeatransactioncount) to get
-    the nonce for an account for the specified privacy group or participants. 
+    the nonce for an account for the specified privacy group or participants.
 
 ## priv_distributeRawTransaction
 
@@ -59,7 +59,7 @@ By using the [public Ethereum transaction](Transactions.md),
 [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction), you are signing
 and submitting the
 [privacy marker transaction] yourself instead of having it signed by the Besu node, giving you
-greater control over the [privacy marker transaction]. 
+greater control over the [privacy marker transaction].
 
 Use [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction)
 to send [concurrent private transactions](Concurrent-Private-Transactions.md).

--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -194,7 +194,7 @@ As a workaround for this issue, use
 and [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction) to send
 concurrent private transactions. For an example in the
 [web3js-eea library](https://github.com/PegaSysEng/web3js-eea), see
-[`concurrentPrivateTransactions.js`](https://github.com/PegaSysEng/web3js-eea/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js).
+[`concurrentPrivateTransactions.js`](https://github.com/PegaSysEng/web3js-eea/blob/master/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js).
 
 <!-- links ---->
 

--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -21,18 +21,21 @@ transaction is not attempted and you must resubmit the transaction.
     Private transactions either deploy contracts or call contract functions. Ether transfer
     transactions cannot be private.
 
-!!! tip
-
-    [`priv_call`](../../Reference/API-Methods.md#priv_call) returns the same information for private
-    contracts as [`eth_call`](../../Reference/API-Methods.md#eth_call) does for non-private
-    contracts.
-
 ## eea_sendRawTransaction
 
 [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction) distributes the
 private transaction to the participating nodes, and signs and submits the
 [privacy marker transaction], as described in
 [Private Transaction Processing](../../Concepts/Privacy/Private-Transaction-Processing.md).
+
+!!! note
+    If sending more than one transaction for mining in the same block (that is, you are not waiting
+    for the transaction receipt), you must calculate the private transaction nonce outside Besu.
+    
+    Use
+    [`priv_getTransactionCount`](../../Reference/API-Methods.md#priv_gettransactioncount) or
+    [`priv_getEeaTransactionCount`](../../Reference/API-Methods.md#priv_geteeatransactioncount) to get
+    the nonce for an account for the specified privacy group or participants. 
 
 ## priv_distributeRawTransaction
 
@@ -56,8 +59,10 @@ By using the [public Ethereum transaction](Transactions.md),
 [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction), you are signing
 and submitting the
 [privacy marker transaction] yourself instead of having it signed by the Besu node, giving you
-greater control over the [privacy marker transaction]. For example, when sending
-[concurrent private transactions](#concurrent_private_transactions).
+greater control over the [privacy marker transaction]. 
+
+Use [`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction)
+to send [concurrent private transactions](Concurrent-Private-Transactions.md).
 
 !!! warning
 
@@ -102,25 +107,6 @@ greater control over the [privacy marker transaction]. For example, when sending
       "id":1
     }
     ```
-
-## Private transaction nonces
-
-Besu maintains separate private states for each
-[privacy group](../../Concepts/Privacy/Privacy-Groups.md) so the nonce for an account is specific
-to the privacy group. That is, the nonce for account A for privacy group ABC is different to the
-nonce for account A for privacy group AB. Use
-[`priv_getTransactionCount`](../../Reference/API-Methods.md#priv_gettransactioncount) or
-[`priv_getEeaTransactionCount`](../../Reference/API-Methods.md#priv_geteeatransactioncount) to get
-the nonce for an account for the specified privacy group.
-
-!!! note
-    If sending more than one transaction for mining in the same block (that is, you are not waiting
-    for the transaction receipt), you must calculate the private transaction nonce outside Besu.
-
-Also, because
-[private transaction processing](../../Concepts/Privacy/Private-Transaction-Processing.md) involves
-two transactions, one for the private transaction and one for the [privacy marker transaction],
-each of these transactions has its own nonce.
 
 ## EEA-compliant or Besu-extended Privacy
 
@@ -175,26 +161,6 @@ private transactions to create a contract.
     The `example` directory in the
     [web3js-eea client library](../Interact/Client-Libraries/web3js-eea.md) contains examples of
     signing and encoding private transactions.
-
-## Concurrent private transactions
-
-As outlined in [Private transaction nonces](#private-transaction-nonces), private transaction
-processing involves two transactions, the private transaction and the [privacy marker transaction],
-with each transaction having its own nonce.
-
-!!! warning
-
-    If you use [`eea_sendRawTransaction`](../../Reference/API-Methods.md#eea_sendrawtransaction) to
-    send concurrent private transactions, situations can occur where the nonce for some or all of
-    the privacy marker transactions are incorrect, causing some or all of the private transactions
-    to fail.
-
-As a workaround for this issue, use
-[`priv_distributeRawTransaction`](../../Reference/API-Methods.md#priv_distributerawtransaction),
-and [`eth_sendRawTransaction`](../../Reference/API-Methods.md#eth_sendrawtransaction) to send
-concurrent private transactions. For an example in the
-[web3js-eea library](https://github.com/PegaSysEng/web3js-eea), see
-[`concurrentPrivateTransactions.js`](https://github.com/PegaSysEng/web3js-eea/blob/master/example/concurrentPrivateTransactions/concurrentPrivateTransactions.js).
 
 <!-- links ---->
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -55,6 +55,9 @@ Enables or disables automatic log bloom caching. APIs such as
 [`eth_getFilterLogs`](../API-Methods.md#eth_getfilterlogs) use the cache for improved performance.
 The default is `true`.
 
+If automatic log bloom caching is enabled and a log bloom query reaches the end of the cache, Besu
+performs an uncached query for logs not yet written to the cache.
+
 Automatic log bloom caching has a small impact on performance. If you are not querying logs blooms
 for a large number of blocks, you might want to disable automatic log bloom caching.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
            - Use Wallets for Key Management: HowTo/Send-Transactions/Account-Management.md
            - Create and Send Transactions: HowTo/Send-Transactions/Transactions.md
            - Create and Send Private Transactions: HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+           - Send Concurrent Private Transactions: HowTo/Send-Transactions/Concurrent-Private-Transactions.md
            - Include Revert Reason in Transaction Receipts: HowTo/Send-Transactions/Revert-Reason.md
         - Limit Access to Node:
           - Use Local Permissioning: HowTo/Limit-Access/Local-Permissioning.md


### PR DESCRIPTION
Added to Creating-Sending-Private-Transactions.md to outline the scenario when sending concurrent private transactions using `eea_sendRawTransaction`, the nonce for the privacy marker transactions be incorrect causing some or all of the private transactions to fail.

Fixes #287 