### PR TITLE
Remove privacy-precompiled-address CLI option

### DIFF
--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -95,7 +95,7 @@ to send [concurrent private transactions](Concurrent-Private-Transactions.md).
     }
     ```
 
-    Send the enclave key in the `data` field, and the privacy precompile address in the `to` field of `eth_sendTransaction`:
+    Send the enclave key in the `data` field, and the [privacy precompile address](../../Reference/API-Methods.md#priv_getprivacyprecompileaddress) in the `to` field of `eth_sendTransaction`:
 
     ```json
     {

--- a/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
+++ b/docs/HowTo/Send-Transactions/Creating-Sending-Private-Transactions.md
@@ -95,7 +95,7 @@ to send [concurrent private transactions](Concurrent-Private-Transactions.md).
     }
     ```
 
-    Send the enclave key in the `data` field of `eth_sendTransaction`:
+    Send the enclave key in the `data` field, and the privacy precompile address in the `to` field of `eth_sendTransaction`:
 
     ```json
     {
@@ -103,6 +103,7 @@ to send [concurrent private transactions](Concurrent-Private-Transactions.md).
       "method":"eth_sendTransaction",
       "params":[{
         "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
+        "to": "0x000000000000000000000000000000000000007e",
         "data": "0xfd0d90ab824574abc19c0776ca0210e764561d0ef6d621f2bbbea316eccfe56b",
         "gas": "0x2E1800",
         "gasPrice": "0x9184e72a000"

--- a/docs/HowTo/Use-Privacy/Use-OnChainPrivacy.md
+++ b/docs/HowTo/Use-Privacy/Use-OnChainPrivacy.md
@@ -54,7 +54,7 @@ the [web3.js-eea library](https://github.com/PegaSysEng/web3js-eea):
 ## Adding and removing members
 
 To add and remove members from an [onchain privacy group](../../Concepts/Privacy/Onchain-PrivacyGroups.md),
-use the `addToPrivacyGroup` and `removeFromPrivayGroup` methods in the [web3.js-eea library](https://github.com/PegaSysEng/web3js-eea)
+use the `addToPrivacyGroup` and `removeFromPrivacyGroup` methods in the [web3.js-eea library](https://github.com/PegaSysEng/web3js-eea)
 client library.
 
 !!! note

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -5374,8 +5374,8 @@ for private contracts.
 ### priv_getPrivacyPrecompileAddress
 
 Returns the address of the
-[privacy precompiled contract](../Concepts/Privacy/Private-Transaction-Processing.md). This address 
-is derived, based on the value of the [`privacy-onchain-groups-enabled`](CLI/CLI-Syntax.md#privacy-onchain-groups-enabled) 
+[privacy precompiled contract](../Concepts/Privacy/Private-Transaction-Processing.md). This address
+is derived, based on the value of the [`privacy-onchain-groups-enabled`](CLI/CLI-Syntax.md#privacy-onchain-groups-enabled)
 option.
 
 #### Parameters

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -5497,7 +5497,7 @@ Privacy groups containing only the specified members. Privacy groups are
 or [Besu-extended](../Concepts/Privacy/Privacy-Groups.md#besu-extended-privacy) with types:
 
 * `LEGACY` for EEA-compliant groups.
-* `BESU` for Besu-extended groups.
+* `PANTHEON` for Besu-extended groups.
 
 !!! example
 

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -5374,9 +5374,9 @@ for private contracts.
 ### priv_getPrivacyPrecompileAddress
 
 Returns the address of the
-[privacy precompiled contract](../Concepts/Privacy/Private-Transaction-Processing.md). Specify the
-address using the [`--privacy-precompiled-address`](CLI/CLI-Syntax.md#privacy-precompiled-address)
-command line option.
+[privacy precompiled contract](../Concepts/Privacy/Private-Transaction-Processing.md). This address 
+is derived, based on the value of the [`privacy-onchain-groups-enabled`](CLI/CLI-Syntax.md#privacy-onchain-groups-enabled) 
+option.
 
 #### Parameters
 

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -172,6 +172,39 @@ Generates cached log bloom indexes for blocks. APIs such as [`eth_getLogs`](#eth
     }
     ```
 
+### admin_logsRepairCache
+
+Repairs cached logs by fixing all segments starting with the specified block number.
+
+#### Parameters
+
+`quantity` - Decimal index of the starting block to fix. If left empty, the head block
+is used as the starting point.
+
+#### Returns
+
+`result` -  Status of the repair request; either `Started`, or `Already running`.
+
+!!! example
+
+    ```bash tab="curl HTTP request"
+    curl -X POST --data '{"jsonrpc":"2.0","method":"admin_logsRepairCache","params":["1200"], "id":1}' http://127.0.0.1:8545
+    ```
+
+    ```bash tab="wscat WS request"
+    {"jsonrpc":"2.0","method":"admin_logsRepairCache","params":["1200"], "id":1}
+    ```
+
+    ```json tab="JSON result"
+    {
+      "jsonrpc": "2.0",
+      "id": 1,
+      "result": {
+        "Status": "Started"
+      }
+    }
+    ```
+
 ### admin_nodeInfo
 
 Returns networking information about the node. The information includes general information about

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1278,19 +1278,10 @@ BESU_PRIVACY_ONCHAIN_GROUPS_ENABLED=true
 ```
 
 ```bash tab="Configuration File"
-privacy-multi-tenancy-enabled=true
+privacy-onchain-groups-enabled=true
 ```
 
 Set to enable onchain privacy groups. Default is `false`.
-
-### privacy-precompiled-address
-
-```bash tab="Syntax"
---privacy-precompiled-address=<privacyPrecompiledAddress>
-```
-
-The [predefined contract address](../../Concepts/Privacy/Private-Transaction-Processing.md). The
-default is 126.
 
 ### privacy-public-key-file
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -1332,19 +1332,19 @@ false.
 ### privacy-tls-keystore-file
 
 ```bash tab="Syntax"
---privacy-tls-keystore-password-file=<FILE>
+--privacy-tls-keystore-file=<FILE>
 ```
 
 ```bash tab="Command Line"
---privacy--keystore-password-file=/home/me/me_node/password
+--privacy--keystore-file=/home/me/me_node/key
 ```
 
 ```bash tab="Environment Variable"
-BESU_PRIVACY_TLS_KEYSTORE_PASSWORD_FILE=/home/me/me_node/password
+BESU_PRIVACY_TLS_KEYSTORE_FILE=/home/me/me_node/key
 ```
 
 ```bash tab="Configuration File"
-privacy-tls-keystore-password-file="/home/me/me_node/password"
+privacy-tls-keystore-file="/home/me/me_node/key"
 ```
 
 The keystore file (in PKCS #12 format) containing the private key and the certificate presented


### PR DESCRIPTION
Remove deprecated --privacy-precompiled-address CLI option. 

## Issue fixed

See #465 

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation
