### PR TITLE
[MINOR] typo plus fixed link to priv_getEeaTransactionCount

### DIFF
--- a/docs/Concepts/Privacy/Private-Transaction-Processing.md
+++ b/docs/Concepts/Privacy/Private-Transaction-Processing.md
@@ -18,7 +18,7 @@ Processing private transactions involves the following:
 
 Private transaction processing is illustrated and described in the following diagram.
 
-![Processing Private Transctions](../../images/PrivateTransactionProcessing.png)
+![Processing Private Transactions](../../images/PrivateTransactionProcessing.png)
 
 1. Submit a private transaction using
   [eea_sendRawTransaction](../../Reference/API-Methods.md#eea_sendrawtransaction). The signed

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -251,7 +251,7 @@ file.
 
 Network conditions might not allow voting to change validators. For example, if a majority
 of the current validators are no longer participating in the network, so a vote to add or remove
-valiators will never be successful. You can bypass voting and specify new validators in the genesis
+validators will never be successful. You can bypass voting and specify new validators in the genesis
 file.
 
 To add or remove validators without voting:

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -4827,7 +4827,7 @@ one object per call, in transaction execution order.
 
 ### trace_transaction
 
-Provides transaction processing of [type `trace`](Trace-Types.md#trace) for the specified transction.
+Provides transaction processing of [type `trace`](Trace-Types.md#trace) for the specified transaction.
 
 !!! important
 
@@ -5411,7 +5411,7 @@ Returns the private transaction if you are a participant; otherwise, `null`.
 #### Parameters
 
 `data` - Transaction hash returned by [`eea_sendRawTransaction`](#eea_sendrawtransaction) or
-[`eea_sendTransction`](https://docs.ethsigner.pegasys.tech/en/latest/Using-EthSigner/Using-EthSigner/#eea_sendtransaction).
+[`eea_sendTransaction`](https://docs.ethsigner.pegasys.tech/en/latest/Using-EthSigner/Using-EthSigner/#eea_sendtransaction).
 
 #### Returns
 

--- a/docs/Reference/web3js-eea-Methods.md
+++ b/docs/Reference/web3js-eea-Methods.md
@@ -14,7 +14,7 @@ The Options parameter has the following properties:
 * `privateKey`: Ethereum private key with which to sign the transaction.
 * `privateFrom` : Orion public key of the sender.
 * [`privateFor` : Orion public keys of recipients or `privacyGroupId`: Privacy group to receive the transaction](../Concepts/Privacy/Privacy-Groups.md)
-* `nonce` : Optional. If not provided, calculated using [`priv_getEeaTransactionCount`](API-Methods#priv_geteeatransactioncount).
+* `nonce` : Optional. If not provided, calculated using [`priv_getEeaTransactionCount`](API-Methods.md#priv_geteeatransactioncount).
 * `to` : Optional. Contract address to send the transaction to. Do not specify for contract
   deployment transactions.
 * `data` : Transaction data.

--- a/docs/Reference/web3js-eea-Methods.md
+++ b/docs/Reference/web3js-eea-Methods.md
@@ -14,7 +14,7 @@ The Options parameter has the following properties:
 * `privateKey`: Ethereum private key with which to sign the transaction.
 * `privateFrom` : Orion public key of the sender.
 * [`privateFor` : Orion public keys of recipients or `privacyGroupId`: Privacy group to receive the transaction](../Concepts/Privacy/Privacy-Groups.md)
-* `nonce` : Optional. If not provided, calculated using [`priv_getEeaTransactionCount`](API-Methods.md#priv_geteeatransactioncount).
+* `nonce` : Optional. If not provided, calculated using [`priv_getEeaTransactionCount`](API-Methods.md#priv_geteeatransactioncount) if Orion public keys of recipients specified, or [`priv_getTransactionCount`](API-Methods.md#priv_gettransactioncount) if `privacyGroupId` is specified.
 * `to` : Optional. Contract address to send the transaction to. Do not specify for contract
   deployment transactions.
 * `data` : Transaction data.

--- a/docs/Reference/web3js-eea-Methods.md
+++ b/docs/Reference/web3js-eea-Methods.md
@@ -14,7 +14,7 @@ The Options parameter has the following properties:
 * `privateKey`: Ethereum private key with which to sign the transaction.
 * `privateFrom` : Orion public key of the sender.
 * [`privateFor` : Orion public keys of recipients or `privacyGroupId`: Privacy group to receive the transaction](../Concepts/Privacy/Privacy-Groups.md)
-* `nonce` : Optional. If not provided, calculated using [`eea_getTransctionCount`](API-Methods.md).
+* `nonce` : Optional. If not provided, calculated using [`priv_getEeaTransactionCount`](API-Methods#priv_geteeatransactioncount).
 * `to` : Optional. Contract address to send the transaction to. Do not specify for contract
   deployment transactions.
 * `data` : Transaction data.


### PR DESCRIPTION
Fixed "transaction" typo and fixed link text for eeaTransactionCount

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation