### PR TITLE
Typo filter

### DIFF
--- a/docs/HowTo/Interact/APIs/Authentication.md
+++ b/docs/HowTo/Interact/APIs/Authentication.md
@@ -30,7 +30,7 @@ Using JSON-RPC authentication and authorization with [MetaMask](https://metamask
 
 Enable authentication from the command line. Supply the credentials file and send a request to the
 `/login` endpoint using the username and password. The `/login` endpoint creates a JWT for making
-permitted JSON RPC requests.
+permitted JSON-RPC requests.
 
 Using [public key authentication](#jwt-public-key-authentication) disables the `/login` endpoint.
 

--- a/docs/HowTo/Interact/APIs/Using-JSON-RPC-API.md
+++ b/docs/HowTo/Interact/APIs/Using-JSON-RPC-API.md
@@ -99,7 +99,7 @@ curl -v 'http://localhost:8545/readiness'
 curl -v 'http://localhost:8545/readiness?minPeers=0&maxBlocksBehind=10'
 ```
 
-The liveness check requires the JSON RPC server to be up.
+The liveness check requires the JSON-RPC server to be up.
 
 ```bash tab="Liveness Endpoint"
 http://<JSON-RPC-HTTP-endpoint:port>/liveness

--- a/docs/HowTo/Interact/Filters/Accessing-Logs-Using-JSON-RPC.md
+++ b/docs/HowTo/Interact/Filters/Accessing-Logs-Using-JSON-RPC.md
@@ -169,7 +169,7 @@ for the `priv` methods.
 
 !!! example
 
-    ```
+    ```json
     {
         "jsonrpc": "2.0",
         "method": "priv_newFilter",
@@ -195,7 +195,7 @@ for a private contract.
 !!! example
 
     The following request for `eth_getLogs` returns all the logs where the example contract has
-    been deployed to 0x42699a7612a82f1d9c36148af9c77354759b210b and executed with `valueIndexed`
+    been deployed to `0x42699a7612a82f1d9c36148af9c77354759b210b` and executed with `valueIndexed`
     set to 5.
 
     ```json
@@ -217,6 +217,6 @@ for a private contract.
     }
     ```
 
-    The above example returns the same result as calling [eth_newFilter](#creating-a-fitler)
+    The above example returns the same result as calling [eth_newFilter](#creating-a-filter)
     followed by [eth_getFilterLogs](#getting-all-logs-for-a-filter).
 

--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -81,11 +81,11 @@ This example changes the debug level for specified classes to `DEBUG`.
 !!! example
 
     ```bash tab="curl HTTP request"
-    curl -X POST --data '{"jsonrpc":"2.0", "method":"admin_changeLogLevel", "params":["DEBUG", ["tech.pegasys.pantheon.ethereum.eth.manager","tech.pegasys.pantheon.ethereum.p2p.rlpx.connections.netty.ApiHandler"]], "id":1}' http://127.0.0.1:8545
+    curl -X POST --data '{"jsonrpc":"2.0", "method":"admin_changeLogLevel", "params":["DEBUG", ["tech.pegasys.besu.ethereum.eth.manager","tech.pegasys.besu.ethereum.p2p.rlpx.connections.netty.ApiHandler"]], "id":1}' http://127.0.0.1:8545
     ```
 
     ```bash tab="wscat WS request"
-    {"jsonrpc":"2.0", "method":"admin_changeLogLevel", "params":["DEBUG", ["tech.pegasys.pantheon.ethereum.eth.manager","tech.pegasys.pantheon.ethereum.p2p.rlpx.connections.netty.ApiHandler"]], "id":1}
+    {"jsonrpc":"2.0", "method":"admin_changeLogLevel", "params":["DEBUG", ["tech.pegasys.besu.ethereum.eth.manager","tech.pegasys.besu.ethereum.p2p.rlpx.connections.netty.ApiHandler"]], "id":1}
     ```
 
     ```json tab="JSON result"

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -665,7 +665,7 @@ BESU_MINER_COINBASE=fe3b557e8fb62b89f4916b721be55ceb828dbd73
 
 The account you pay mining rewards to. You must specify a valid coinbase when you enable mining
 using the [`--miner-enabled`](#miner-enabled) option or the
-[`miner_start`](../API-Methods.md#miner_start) JSON RPC-API method.
+[`miner_start`](../API-Methods.md#miner_start) JSON-RPC API method.
 
 !!!note
 


### PR DESCRIPTION
Fixed typo. Also changed package name in examples from pantheon to besu

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation