### PR TITLE
Update changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 For changes see the Hyperledger Besu
-[CHANGELOG.md](https://github.com/shemnon/besu/blob/master/CHANGELOG.md)
+[CHANGELOG.md](https://github.com/hyperledger/besu/blob/master/CHANGELOG.md)


### PR DESCRIPTION
Makes the changelog link point to the Hyperledger Besu repo 

Fixes https://github.com/hyperledger/besu-docs/issues/358