### PR TITLE
fix 404 page links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ to propose changes to this document in a pull request.
 * [Reporting bugs in the documentation]
 * [Submitting a documentation enhancement suggestion]
 * [Documentation style guide]
-* [Pull request labels](https://wiki.hyperledger.org/display/BESU/Pull+Request+Labels)
 * [Security](SECURITY.md)
 
 ### Other important information

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -18,8 +18,7 @@
 </p>
 <p style="text-align: center">
   If you think we made a mistake and deleted a page that should be here, then please tell us on
-  <a href="{{config.extra.support.gitter}}">{{config.site_name}} chat channel</a> or create an issue in
-  <a href="{{config.extra.support.issues}}">{{config.site_name}} Jira</a>.
+  <a href="{{config.extra.support.chat}}">{{config.site_name}} chat channel</a> or <a href="{{config.extra.support.issues}}">create an issue</a>.
 </p>
 
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "test:links:check": "find . -name \\*.md ! -path \"./node_modules/*\" -exec ./node_modules/markdown-link-check/markdown-link-check -q -c CI/linkchecker/link_check_conf.json {} \\; > linkchecker.out 2>&1",
+    "test:links:check": "find . -name \\*.md ! -path \"./node_modules/*\" -exec ./node_modules/markdown-link-check/markdown-link-check -q -c CI/linkchecker/link_check_conf.json {} \\; 2>&1 | tee linkchecker.out",
     "test:links:display": "cat linkchecker.out",
-    "test:links:verify": "! grep 'ERROR:' linkchecker.out",
+    "test:links:verify": "! grep -n '[✖]\\|ERROR' ./linkchecker.out",
     "test:links": "npm run test:links:check && npm run test:links:display && npm run test:links:verify",
     "test": "npm run test:links"
   },


### PR DESCRIPTION
Signed-off-by: Nicolas MASSART <nicolas.massart@consensys.net>

**Before pushing any commit in your pull request, make sure that you:**

- [x] read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Contributing+to+documentation).
- [x] [signed all commits of for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] have [tested your changes locally](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewTheDocumentation) before submitting them to the community for review. -->

## Describe the change

<!-- A clear and concise description of what this PR changes in the documentation. -->
- Fix the issue link and text on 404 page
- Also fixes a link that prevents to merge as the "Pull request labels" wiki page was removed.
- Make the link checker command check for x and use tee to help see the check progress to make it easier to look at in CircleCI UI.

## Issue fixed

<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

404 page was displaying Jira even if we don't use it anymore. the link was ok.

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [x] Build and QA tools (lint, vale,…)
- [x] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] Github integration

## Testing

<!-- Steps to follow to review and test your changes. -->
Go to https://hyperledger-besu--501.org.readthedocs.build/en/501/non-existent-page and check issues link

For the other changes in link checks, it only impacts the CI steps, so if they all passed, it's ok.