### PR TITLE
[MINOR] Corrected param name blockhash -> blockHash

### DIFF
--- a/docs/Reference/API-Objects.md
+++ b/docs/Reference/API-Objects.md
@@ -51,7 +51,7 @@ extra key.
 
 | Key           | Type               | Required/Optional | Value  |
 |---------------|:------------------:|:-----------------:|--------|
-| **blockhash** |Data, 32&nbsp;bytes | Optional.         | Hash of block for which to return logs. If you specify `blockhash`, you cannot specify `fromBlock` and `toBlock`. |
+| **blockHash** |Data, 32&nbsp;bytes | Optional.         | Hash of block for which to return logs. If you specify `blockHash`, you cannot specify `fromBlock` and `toBlock`. |
 
 ## Log object
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Correct name of blockHash param

## Issue fixed

See https://github.com/hyperledger/besu/issues/1540

### For content changes

- [x] Doc content
- [ ] Doc pages organisation