### PR TITLE
move Steven and Grant to emeritus maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,20 +11,15 @@
 | Byron Gravenorst | bgravenorst      | bgravenorst      |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
-| Steven Gregg     | sgregglives      | sagregg          |
-| Grant Noble      | grantnoble       | grantnoble       |
 <!-- vale on -->
 
 ## Emeritus maintainers
 
-None.
-
 <!-- vale off -->
-<!--
-| Name | Github | LFID |
-|------|--------|------|
-| null | null   | null |
--->
+| Name             | GitHub           | LFID             |
+| ---------------- | ---------------- | ---------------- |
+| Steven Gregg     | sgregglives      | sagregg          |
+| Grant Noble      | grantnoble       | grantnoble       |
 <!-- vale on -->
 
 ## Becoming a maintainer


### PR DESCRIPTION
Move Steven and Grant to emeritus maintainers list.
The reason is inactivity

See https://github.com/hyperledger/besu-docs/blob/master/MAINTAINERS.md#removing-maintainers

fixes #623 