### PR TITLE
BESU_CONFIG_FILE is not actually supported still

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -304,12 +304,6 @@ The default is `false`.
     --config-file=/home/me/me_node/config.toml
     ```
 
-=== "Environment Variable"
-
-    ```bash
-    BESU_CONFIG_FILE=/home/me/me_node/config.toml
-    ```
-
 The path to the [TOML configuration file](../../HowTo/Configure/Using-Configuration-File.md).
 The default is `none`.
 


### PR DESCRIPTION
## Describe the change

Using environment variable for config file does not work.
Based on personal experience and some code research.
Please check the file:
https://github.com/hyperledger/besu/blob/master/besu/src/main/java/org/hyperledger/besu/cli/util/ConfigOptionSearchAndRunHandler.java#L63

**This does not read config.toml**
`BESU_CONFIG_FILE=/path/to/config.toml besu `

**This works well**
`besu --config-file=/path/to/config.toml`

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

## Screenshots / recording

<!-- If it helps understanding your change,
don't hesitate to link an annotated screenshot or a small demo video. -->
