### PR TITLE
[MINOR] fixed typo

### DIFF
--- a/docs/global/Config-Options.md
+++ b/docs/global/Config-Options.md
@@ -5,7 +5,7 @@ Optional configuration options in the genesis file are:
 
 * `messageQueueLimit` - In large networks with limited resources, increasing the message queue
   limit might help with message activity surges. The default is 1000.
-* `duplicateMesageLimit` - If the same node is retransmitting messages, increasing the duplicate
+* `duplicateMessageLimit` - If the same node is retransmitting messages, increasing the duplicate
   message limit might reduce the number of retransmissions. A value of two to three times the
   number of validators is usually enough. The default is 100.
 * `futureMessagesLimit` - The future messages buffer holds messages for a future chain


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Mesage -> Message
I checked besu code and it has the correct spelling

  public int getDuplicateMessageLimit() {
    return JsonUtil.getInt(bftConfigRoot, "duplicatemessagelimit", DEFAULT_DUPLICATE_MESSAGE_LIMIT);
  }

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration