### PR TITLE
Add note to eth_syncing to clarify behaviour

### DIFF
--- a/docs/Reference/API-Methods.md
+++ b/docs/Reference/API-Methods.md
@@ -4616,6 +4616,10 @@ This is used by mining software such as [Ethminer](https://github.com/ethereum-m
 
 Returns an object with data about the synchronization status, or `false` if not synchronizing.
 
+!!! note
+
+    Once the node reaches the head of the chain, `eth_syncing` returns false, indicating that there is no active syncing target.
+
 #### Parameters
 
 None


### PR DESCRIPTION
## Pull request checklist

### Before creating the pull request

Make sure that:

- [x] [all commits in this PR are signed off for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] you read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Contributing+to+documentation).
- [x] you have [tested your changes locally](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewTheDocumentation) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [ ] you fixed all the issues raised by the tests, if any.
- [ ] you verified the rendering of your changes on [ReadTheDocs.org PR preview](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewwithReadTheDocs)
  and updated the testing link (see [Testing](#testing)).

## Describe the change

Clarifying be haviour of `eth_syncing`.

Based on https://chat.hyperledger.org/channel/besu?msg=upgTmbuQNczHr8RBK

## Issue fixed

N/A

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration
