### PR TITLE
[MINOR] missing single quote

### DIFF
--- a/docs/HowTo/Use-Privacy/Use-FlexiblePrivacy.md
+++ b/docs/HowTo/Use-Privacy/Use-FlexiblePrivacy.md
@@ -48,6 +48,7 @@ the [`web3js-quorum` library](https://github.com/ConsenSys/web3js-quorum):
 1. Run:
 
     ```bash
+    cd example/onchainPrivacy
     node simpleExample.js
     ```
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Added a missing single quote to fix formatting

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration
