### PR TITLE
[MINOR] typo

### DIFF
--- a/docs/Concepts/Privacy/Private-Transactions.md
+++ b/docs/Concepts/Privacy/Private-Transactions.md
@@ -49,7 +49,7 @@ keys of the Tessera nodes sending and receiving the transaction.
 
 [Private transaction processing](../../Concepts/Privacy/Private-Transaction-Processing.md) involves
 two transactions, the private transaction distributed to involved participants and the
-[privacy marker transaction] included on the public blockchain. Each each of these transactions has
+[privacy marker transaction] included on the public blockchain. Each of these transactions has
 its own nonce.
 
 ### Private transaction nonce


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

removed duplicate word: each

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration