### PR TITLE
Remove a word from the list of accepted terms.

### DIFF
--- a/CI/vale/vale_styles/Vocab/Besu/accept.txt
+++ b/CI/vale/vale_styles/Vocab/Besu/accept.txt
@@ -1,4 +1,3 @@
-[aA]busable
 Alethio
 [aA]llowlist(s)?
 Ansible


### PR DESCRIPTION
Signed-off-by: bgravenorst <byron.gravenorst@consensys.net>

## Describe the change

Removed the word "abusable" from the list of accepted terms.
