### PR TITLE
Add discovery object to genesis config items

### DIFF
--- a/docs/Reference/Config-Items.md
+++ b/docs/Reference/Config-Items.md
@@ -24,6 +24,7 @@ Network configuration items are specified in the genesis file in the `config` ob
 | `evmStackSize`      | Maximum stack size. Specify to increase the maximum stack size in private networks with complex smart contracts. The default is `1024`.                                                     |
 | `isQuorum`          | Set to `true` to allow [interoperable private transactions] between Hyperledger Besu and [GoQuorum clients] using the Tessera private transaction manager.                                  |
 | `ecCurve`           | Specifies [the elliptic curve to use](../HowTo/Configure/Alternative-EC-Curves.md). Default is `secp256k1`.                                                                                 |
+| `discovery`         | Specifies the discovery options and contains the [discovery configuration items](#discovery-configuration-items). The `discovery` object can be left empty.                             |
 
 ## Genesis block parameters
 
@@ -117,6 +118,28 @@ the network's difficulty constant and override the `difficulty` parameter from t
     Using `fixeddifficulty` is not recommended for use with Ethash outside of test environments.
     For production networks using Ethash, we recommend setting a low `difficulty` value in the genesis file instead.
     Ethash will adjust the difficulty of the network based on hashrate to produce blocks at the targeted frequency.
+
+## Discovery configuration items
+
+Use the `discovery` configuration items to specify the [`bootnodes`](CLI/CLI-Syntax.md#bootnodes) and [`discovery-dns-url`](CLI/CLI-Syntax.md#discovery-dns-url)
+in the genesis file, in place of using CLI options or listing them in the configuration file.
+If either CLI option is used, it takes precedence over the genesis file.
+Anything listed in the configuration file also takes precedence.
+
+!!! example
+
+    ```json
+    {
+      "config": {
+          "discovery" : {
+              "bootnodes": [
+                  "enode://c35c3...d615f@1.2.3.4:30303",
+                  "enode://f42c13...fc456@1.2.3.5:30303"
+              ],
+              "dns": "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@nodes.example.org"
+          }
+    }
+    ```
 
 <!--links-->
 [GoQuorum clients]: https://docs.goquorum.consensys.net/

--- a/docs/Reference/Config-Items.md
+++ b/docs/Reference/Config-Items.md
@@ -24,7 +24,7 @@ Network configuration items are specified in the genesis file in the `config` ob
 | `evmStackSize`      | Maximum stack size. Specify to increase the maximum stack size in private networks with complex smart contracts. The default is `1024`.                                                     |
 | `isQuorum`          | Set to `true` to allow [interoperable private transactions] between Hyperledger Besu and [GoQuorum clients] using the Tessera private transaction manager.                                  |
 | `ecCurve`           | Specifies [the elliptic curve to use](../HowTo/Configure/Alternative-EC-Curves.md). Default is `secp256k1`.                                                                                 |
-| `discovery`         | Specifies the discovery options and contains the [discovery configuration items](#discovery-configuration-items). The `discovery` object can be left empty.                             |
+| `discovery`         | Specifies [discovery configuration items](#discovery-configuration-items). The `discovery` object can be left empty.                                                                        |
 
 ## Genesis block parameters
 

--- a/docs/Reference/Config-Items.md
+++ b/docs/Reference/Config-Items.md
@@ -138,6 +138,7 @@ Anything listed in the configuration file also takes precedence.
               ],
               "dns": "enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@nodes.example.org"
           }
+      }
     }
     ```
 


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Added `discovery` object to genesis config items. 
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #858 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--875.org.readthedocs.build/en/875/Reference/Config-Items/
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

## Screenshots / recording

<!-- If it helps understanding your change,
don't hesitate to link an annotated screenshot or a small demo video. -->
