### PR TITLE
Document maximum number of IBFT 2.0 validators

### DIFF
--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -37,7 +37,7 @@ propagating incorrect information to peers.
 
 As the number of validators increase, the message complexity increases as well, which can cause a loss of performance.
 In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators safely with no loss of performance.
-After 35 validators, transaction pool time grows exponentially. 
+After 35 validators, transaction pool time grows exponentially.
 
 ## Genesis file
 

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -25,11 +25,19 @@ Existing validators propose and vote to
 [add or remove validators](Add-Validators.md#ibft-20). Adding or removing a validator
 requires a majority vote (greater than 50%) of validators.
 
-## Minimum number of validators
+## Validators
+
+### Minimum number of validators
 
 IBFT 2.0 requires four validators to be Byzantine fault tolerant. Byzantine fault tolerance is the
 ability for a blockchain network to function correctly and reach consensus despite nodes failing or
 propagating incorrect information to peers.
+
+### Maximum number of validators
+
+As the number of validators increase, the message complexity increases as well, which can cause a loss of performance.
+In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators safely with no loss of performance.
+After 35 validators, transaction pool time grows exponentially. 
 
 ## Genesis file
 

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -37,6 +37,7 @@ propagating incorrect information to peers.
 
 As the number of validators increase, the message complexity increases as well, which can cause a loss of performance.
 In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators safely with no loss of performance.
+Non-validator nodes do not affect performance and do not count towards the maximum limit.
 
 ## Genesis file
 

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -37,7 +37,6 @@ propagating incorrect information to peers.
 
 As the number of validators increase, the message complexity increases as well, which can cause a loss of performance.
 In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators safely with no loss of performance.
-After 35 validators, transaction pool time grows exponentially.
 
 ## Genesis file
 

--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -35,9 +35,10 @@ propagating incorrect information to peers.
 
 ### Maximum number of validators
 
-As the number of validators increase, the message complexity increases as well, which can cause a loss of performance.
-In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators safely with no loss of performance.
-Non-validator nodes do not affect performance and do not count towards the maximum limit.
+As the number of validators increase, the message complexity increases, which can decrease performance.
+In [network tests](https://wiki.hyperledger.org/display/BESU/Maximum+Validator+count+for+an+IBFT2+Network), IBFT 2.0 handles up to 30 validators with no loss of performance.
+
+Non-validator nodes don't affect performance and don't count towards the maximum limit.
 
 ## Genesis file
 


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Pull request checklist

## Describe the change
Document maximum number of validators for IBFT 2.0 networks.
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #877 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--895.org.readthedocs.build/en/895/HowTo/Configure/Consensus-Protocols/IBFT/
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

