### PR TITLE
Add TLS configuration options

### DIFF
--- a/docs/HowTo/Configure/TLS/Configure-TLS.md
+++ b/docs/HowTo/Configure/TLS/Configure-TLS.md
@@ -75,9 +75,9 @@ The command line:
 * [Specifies the clients](#create-the-known-clients-file) allowed to connect to Besu using the
   [`--rpc-http-tls-known-clients-file`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-known-clients-file) option.
 * specifies the Java cipher suites using the
-  [`--rpc-http-tls-cipher-suite`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-cipher-suite-rpc-http-tls-cipher-suites) option.
+  [`--rpc-http-tls-cipher-suite`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-cipher-suite) option.
 * specifies the TLS protocol version using the
-  [`--rpc-http-tls-protocol`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-protocol-rpc-http-tls-protocols) option.
+  [`--rpc-http-tls-protocol`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-protocol) option.
 
 !!! note
 

--- a/docs/HowTo/Configure/TLS/Configure-TLS.md
+++ b/docs/HowTo/Configure/TLS/Configure-TLS.md
@@ -74,9 +74,9 @@ The command line:
   [`--rpc-http-tls-keystore-password-file`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-keystore-password-file) option.
 * [Specifies the clients](#create-the-known-clients-file) allowed to connect to Besu using the
   [`--rpc-http-tls-known-clients-file`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-known-clients-file) option.
-* specify the Java cipher suites using the
+* specifies the Java cipher suites using the
   [`--rpc-http-tls-cipher-suite`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-cipher-suite-rpc-http-tls-cipher-suites) option.
-* specify the TLS protocol version using the
+* specifies the TLS protocol version using the
   [`--rpc-http-tls-protocol`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-protocol-rpc-http-tls-protocols) option.
 
 !!! note

--- a/docs/HowTo/Configure/TLS/Configure-TLS.md
+++ b/docs/HowTo/Configure/TLS/Configure-TLS.md
@@ -56,7 +56,7 @@ the SHA256 fingerprint.
 ### Start Besu
 
 ```bash
-besu --rpc-http-enabled --rpc-http-tls-enabled --rpc-http-tls-client-auth-enabled --rpc-http-tls-keystore-file=/Users/me/my_node/keystore.pfx --rpc-http-tls-keystore-password-file=/Users/me/my_node/keystorePassword --rpc-http-tls-known-clients-file=/Users/me/my_node/knownClients
+besu --rpc-http-enabled --rpc-http-tls-enabled --rpc-http-tls-client-auth-enabled --rpc-http-tls-keystore-file=/Users/me/my_node/keystore.pfx --rpc-http-tls-keystore-password-file=/Users/me/my_node/keystorePassword --rpc-http-tls-known-clients-file=/Users/me/my_node/knownClients --rpc-http-tls-cipher-suite=TLS_AES_256_GCM_SHA384 --rpc-http-tls-protocol=TLSv1.3,TLSv1.2
 ```
 
 The command line:
@@ -74,6 +74,10 @@ The command line:
   [`--rpc-http-tls-keystore-password-file`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-keystore-password-file) option.
 * [Specifies the clients](#create-the-known-clients-file) allowed to connect to Besu using the
   [`--rpc-http-tls-known-clients-file`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-known-clients-file) option.
+* specify the Java cipher suites using the
+  [`--rpc-http-tls-cipher-suite`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-cipher-suite-rpc-http-tls-cipher-suites) option.
+* specify the TLS protocol version using the
+  [`--rpc-http-tls-protocol`](../../../Reference/CLI/CLI-Syntax.md#rpc-http-tls-protocol-rpc-http-tls-protocols) option.
 
 !!! note
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2899,7 +2899,7 @@ Enables TLS client authentication for the JSON-RPC HTTP service. The default is 
 === "Configuration file"
 
     ```bash
-    rpc-http-tls-cipher-suite=["TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+    rpc-http-tls-cipher-suite=["TLS_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
     ```
 
 A list of comma separated TLS cipher suites to support.
@@ -3048,7 +3048,7 @@ Must contain the certificates's Common Name, and SHA-256 fingerprint in the form
 === "Configuration file"
 
     ```bash
-    rpc-http-tls-protocol=["TLSv1.3,TLSv1.2"]
+    rpc-http-tls-protocol=["TLSv1.3","TLSv1.2"]
     ```
 
 A list of comma separated TLS protocols to support. Defaults to `DEFAULT_TLS_PROTOCOLS`, a list which includes `TLSv1.3` and `TLSv1.2`.

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2876,7 +2876,7 @@ Enables TLS client authentication for the JSON-RPC HTTP service. The default is 
     You must specify [`--rpc-http-tls-ca-clients-enabled`](#rpc-http-tls-ca-clients-enabled) and/or
     [`rpc-http-tls-known-clients-file`](#rpc-http-tls-known-clients-file).
 
-### `rpc-http-tls-cipher-suite`, `rpc-http-tls-cipher-suites`
+### `rpc-http-tls-cipher-suite`
 
 === "Syntax"
 
@@ -3030,7 +3030,7 @@ Must contain the certificates's Common Name, and SHA-256 fingerprint in the form
     You must enable client authentication using the
     [`---rpc-http-tls-client-auth-enabled`](#rpc-http-tls-client-auth-enabled) option.
 
-### `rpc-http-tls-protocol`, `rpc-http-tls-protocols`
+### `rpc-http-tls-protocol`
 
 === "Syntax"
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2902,7 +2902,12 @@ Enables TLS client authentication for the JSON-RPC HTTP service. The default is 
     rpc-http-tls-cipher-suite=["TLS_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
     ```
 
-A list of comma separated TLS cipher suites to support.
+A list of comma-separated TLS cipher suites to support.
+
+!!!tip
+
+    The singular `--rpc-http-tls-cipher-suite` and plural `--rpc-http-tls-cipher-suites` are available and are two names for
+    the same option.
 
 ### `rpc-http-tls-enabled`
 
@@ -3051,7 +3056,12 @@ Must contain the certificates's Common Name, and SHA-256 fingerprint in the form
     rpc-http-tls-protocol=["TLSv1.3","TLSv1.2"]
     ```
 
-A list of comma separated TLS protocols to support. Defaults to `DEFAULT_TLS_PROTOCOLS`, a list which includes `TLSv1.3` and `TLSv1.2`.
+A list of comma-separated TLS protocols to support. The default is `DEFAULT_TLS_PROTOCOLS`, a list which includes `TLSv1.3` and `TLSv1.2`.
+
+!!!tip
+
+    The singular `--rpc-http-tls-protocol` and plural `--rpc-http-tls-protocols` are available and are two names for
+    the same option.
 
 ### `rpc-tx-feecap`
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2876,6 +2876,34 @@ Enables TLS client authentication for the JSON-RPC HTTP service. The default is 
     You must specify [`--rpc-http-tls-ca-clients-enabled`](#rpc-http-tls-ca-clients-enabled) and/or
     [`rpc-http-tls-known-clients-file`](#rpc-http-tls-known-clients-file).
 
+### `rpc-http-tls-cipher-suite`, `rpc-http-tls-cipher-suites`
+
+=== "Syntax"
+
+    ```bash
+    --rpc-http-tls-cipher-suite=<cipherSuiteName>[, <cipherSuiteName>...]
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpc-http-tls-cipher-suite=TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    BESU_RPC_HTTP_TLS_CIPHER_SUITE= TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    rpc-http-tls-cipher-suite="TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    ```
+
+A list of comma separated TLS cipher suites to support.
+
 ### `rpc-http-tls-enabled`
 
 === "Syntax"
@@ -2996,6 +3024,34 @@ Must contain the certificates's Common Name, and SHA-256 fingerprint in the form
 
     You must enable client authentication using the
     [`---rpc-http-tls-client-auth-enabled`](#rpc-http-tls-client-auth-enabled) option.
+
+### `rpc-http-tls-protocol`, `rpc-http-tls-protocols`
+
+=== "Syntax"
+
+    ```bash
+    --rpc-http-tls-protocol=<protocolName>[, <protocolName>...]
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpc-http-tls-protocol=TLSv1.3,TLSv1.2
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    BESU_RPC_HTTP_TLS_PROTOCOL=TLSv1.3,TLSv1.2
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    rpc-http-tls-protocol="TLSv1.3,TLSv1.2"
+    ```
+
+A list of comma separated TLS protocols to support. Defaults to `DEFAULT_TLS_PROTOCOLS`, a list which includes `TLSv1.3` and `TLSv1.2`.
 
 ### `rpc-tx-feecap`
 

--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -2893,13 +2893,13 @@ Enables TLS client authentication for the JSON-RPC HTTP service. The default is 
 === "Environment variable"
 
     ```bash
-    BESU_RPC_HTTP_TLS_CIPHER_SUITE= TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    BESU_RPC_HTTP_TLS_CIPHER_SUITE=TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
     ```
 
 === "Configuration file"
 
     ```bash
-    rpc-http-tls-cipher-suite="TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    rpc-http-tls-cipher-suite=["TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
     ```
 
 A list of comma separated TLS cipher suites to support.
@@ -3048,7 +3048,7 @@ Must contain the certificates's Common Name, and SHA-256 fingerprint in the form
 === "Configuration file"
 
     ```bash
-    rpc-http-tls-protocol="TLSv1.3,TLSv1.2"
+    rpc-http-tls-protocol=["TLSv1.3,TLSv1.2"]
     ```
 
 A list of comma separated TLS protocols to support. Defaults to `DEFAULT_TLS_PROTOCOLS`, a list which includes `TLSv1.3` and `TLSv1.2`.


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Add TLS configuration options
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #885 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--900.org.readthedocs.build/en/900/Reference/CLI/CLI-Syntax/#rpc-http-tls-cipher-suite-rpc-http-tls-cipher-suites

https://hyperledger-besu--900.org.readthedocs.build/en/900/HowTo/Configure/TLS/Configure-TLS/#start-besu
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

