### PR TITLE
Clarify wording around gasPrice

### DIFF
--- a/docs/Reference/API-Objects.md
+++ b/docs/Reference/API-Objects.md
@@ -197,7 +197,7 @@ and
 | **chainId**              | Quantity            | [Chain ID](../Concepts/NetworkID-And-ChainID.md).                                          |
 | **from**                 | Data, 20&nbsp;bytes | Address of the sender.                                                                     |
 | **gas**                  | Quantity            | Gas provided by the sender.                                                                |
-| **gasPrice**             | Quantity            | (Optional) Gas price, in Wei, provided by the sender. Not used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
+| **gasPrice**             | Quantity            | (Optional) Gas price, in Wei, provided by the sender. Used only in [non-`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **maxPriorityFeePerGas** | Quantity, Integer   | (Optional) Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **maxFeePerGas**         | Quantity, Integer   | (Optional) Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **hash**                 | Data, 32&nbsp;bytes | Hash of the transaction.                                                                   |
@@ -228,7 +228,7 @@ Parameter for [`eth_call`](API-Methods.md#eth_call) and
 | **from**                 | Data, 20&nbsp;bytes | Address of the sender.                                         |
 | **to**                   | Data, 20&nbsp;bytes | Address of the action receiver.                                |
 | **gas**                  | Quantity, Integer   | Gas provided by the sender. `eth_call` consumes zero gas, but other executions might need this parameter. `eth_estimateGas` ignores this value. |
-| **gasPrice**             | Quantity, Integer   | Gas price, in Wei, provided by the sender. The default is `0`. Can't be used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
+| **gasPrice**             | Quantity, Integer   | Gas price, in Wei, provided by the sender. The default is `0`. Used only in [non-`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **maxPriorityFeePerGas** | Quantity, Integer   | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Can be used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). If used, must specify `maxFeePerGas`. |
 | **maxFeePerGas**         | Quantity, Integer   | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Can be used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). If used, must specify `maxPriorityFeePerGas`. |
 | **value**                | Quantity, Integer   | Value transferred, in Wei.                                     |

--- a/docs/Reference/API-Objects.md
+++ b/docs/Reference/API-Objects.md
@@ -197,7 +197,7 @@ and
 | **chainId**              | Quantity            | [Chain ID](../Concepts/NetworkID-And-ChainID.md).                                          |
 | **from**                 | Data, 20&nbsp;bytes | Address of the sender.                                                                     |
 | **gas**                  | Quantity            | Gas provided by the sender.                                                                |
-| **gasPrice**             | Quantity            | (Optional) Gas price, in Wei, provided by the sender. Used only in [non-`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
+| **gasPrice**             | Quantity            | (Optional) Gas price, in Wei, provided by the sender. Used only in non-[`EIP1559`](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions) transactions. |
 | **maxPriorityFeePerGas** | Quantity, Integer   | (Optional) Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **maxFeePerGas**         | Quantity, Integer   | (Optional) Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
 | **hash**                 | Data, 32&nbsp;bytes | Hash of the transaction.                                                                   |
@@ -228,7 +228,7 @@ Parameter for [`eth_call`](API-Methods.md#eth_call) and
 | **from**                 | Data, 20&nbsp;bytes | Address of the sender.                                         |
 | **to**                   | Data, 20&nbsp;bytes | Address of the action receiver.                                |
 | **gas**                  | Quantity, Integer   | Gas provided by the sender. `eth_call` consumes zero gas, but other executions might need this parameter. `eth_estimateGas` ignores this value. |
-| **gasPrice**             | Quantity, Integer   | Gas price, in Wei, provided by the sender. The default is `0`. Used only in [non-`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). |
+| **gasPrice**             | Quantity, Integer   | Gas price, in Wei, provided by the sender. The default is `0`. Used only in non-[`EIP1559`](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions) transactions. |
 | **maxPriorityFeePerGas** | Quantity, Integer   | Maximum fee, in Wei, the sender is willing to pay per gas above the base fee. Can be used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). If used, must specify `maxFeePerGas`. |
 | **maxFeePerGas**         | Quantity, Integer   | Maximum total fee (base fee + priority fee), in Wei, the sender is willing to pay per gas. Can be used only in [`EIP1559` transactions](../Concepts/Transactions/Transaction-Types.md#eip1559-transactions). If used, must specify `maxPriorityFeePerGas`. |
 | **value**                | Quantity, Integer   | Value transferred, in Wei.                                     |


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Update wording to clarify gasPrice for non-EIP1559 transactions and maxPriorityFeePerGas/maxFeePerGas for EIP1559 transactions.
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #910 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--913.org.readthedocs.build/en/913/Reference/API-Objects/#transaction-object

https://hyperledger-besu--913.org.readthedocs.build/en/913/Reference/API-Objects/#transaction-call-object
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->

## Screenshots / recording

<!-- If it helps understanding your change,
don't hesitate to link an annotated screenshot or a small demo video. -->
