### PR TITLE
Add TX replay protection CLI option

### DIFF
--- a/docs/Reference/CLI/CLI-Syntax.md
+++ b/docs/Reference/CLI/CLI-Syntax.md
@@ -3406,6 +3406,29 @@ Defaults to using the node's local private key file specified using
 Static nodes JSON file containing the [static nodes](../../HowTo/Find-and-Connect/Static-Nodes.md) for this node to
 connect to. Defaults to `datapath/static-nodes.json`.
 
+### `strict-tx-replay-protection-enabled`
+
+=== "Syntax"
+
+    ```bash
+    --strict-tx-replay-protection-enabled=false
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    STRICT_TX_REPLAY_PROTECTION_ENABLED=false
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    strict-tx-replay-protection-enabled=false
+    ```
+
+Requires transactions submitted via JSON-RPC to use replay protection in accordance with [EIP-155](https://eips.ethereum.org/EIPS/eip-155).
+The default is `false`.
+
 ### `sync-mode`
 
 === "Syntax"


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Add `strict-tx-replay-protection-enabled` CLI option 
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #633 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--925.org.readthedocs.build/en/925/Reference/CLI/CLI-Syntax/#strict-tx-replay-protection-enabled
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->
