### PR TITLE
Document troubleshooting IPv6 exception

### DIFF
--- a/docs/HowTo/Troubleshoot/Troubleshooting.md
+++ b/docs/HowTo/Troubleshoot/Troubleshooting.md
@@ -185,3 +185,16 @@ following symptoms:
     ```
 
 * No logs can be downloaded
+
+## Unsupported address exception while running from Docker
+
+While [running Besu from a Docker image](../../HowTo/Get-Started/Installation-Options/Run-Docker-Image.md), you might get the following exception:
+
+```bash
+Unsupported address type exception when connecting to peer {}, this is likely due to ipv6 not being enabled at runtime.
+```
+
+This happens when the IPv6 support in Docker is disabled while connecting to an IPv6 peer, preventing outbound communication.
+IPv6 is disabled by default in Docker.
+
+[Enable IPv6 support in Docker](https://docs.docker.com/config/daemon/ipv6/) to allow outbound IPv6 traffic and allow connection with IPv6 peers.


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>


## Describe the change
Add troubleshooting section for IPv6 exception while running through Docker.
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #853 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--929.org.readthedocs.build/en/929/HowTo/Troubleshoot/Troubleshooting/#unsupported-address-exception-while-running-from-docker
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->
