### PR TITLE
Remove `FATAL` from logging.

### DIFF
--- a/docs/HowTo/Monitor/Logging.md
+++ b/docs/HowTo/Monitor/Logging.md
@@ -18,7 +18,7 @@ Hyperledger Besu uses Log4J2 for logging and provides two methods to configure l
 
 Use the [`--logging`](../../Reference/CLI/CLI-Syntax.md#logging) command line option to specify logging verbosity.
 The [`--logging`](../../Reference/CLI/CLI-Syntax.md#logging) option changes the volume of events displayed in the log.
-Valid log levels are `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
+Valid log levels are `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
 The default level is `INFO`.
 
 For most use cases, the basic method provides enough configurability.


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Remove `FATAL` from logging list.
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #935 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing
https://hyperledger-besu--936.org.readthedocs.build/en/936/HowTo/Monitor/Logging/#basic-logging
<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->
