### PR TITLE
replaced RocketChat with Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ guidelines (not rules) for contributing to this repository. Use your best judgem
 to propose changes to this document in a pull request.
 
 * [Hyperledger Besu documentation](http://besu.hyperledger.org/)
-* [Hyperledger Besu chat](https://chat.hyperledger.org/channel/besu)
+* [Hyperledger Besu chat](https://discord.gg/hyperledger)
 * [Hyperledger Besu Wiki](https://wiki.hyperledger.org/display/BESU/Hyperledger+Besu)
 
 ### Useful docs contributing links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ guidelines (not rules) for contributing to this repository. Use your best judgem
 to propose changes to this document in a pull request.
 
 * [Hyperledger Besu documentation](http://besu.hyperledger.org/)
-* [Hyperledger Besu chat](https://discord.gg/hyperledger)
+* [Hyperledger Besu community](https://discord.gg/hyperledger)
 * [Hyperledger Besu Wiki](https://wiki.hyperledger.org/display/BESU/Hyperledger+Besu)
 
 ### Useful docs contributing links

--- a/DCO.md
+++ b/DCO.md
@@ -14,4 +14,4 @@ command, providing your `user.name` and `user.email` are setup correctly.
 For more information about DCO, see the
 [Besu wiki](https://wiki.hyperledger.org/pages/viewpage.action?pageId=24772914).
 If you have any questions, you can reach us on
-[Besu chat](https://chat.hyperledger.org/channel/besu).
+[Hyperledger Besu chat](https://discord.gg/hyperledger).

--- a/DCO.md
+++ b/DCO.md
@@ -13,5 +13,5 @@ command, providing your `user.name` and `user.email` are setup correctly.
 
 For more information about DCO, see the
 [Besu wiki](https://wiki.hyperledger.org/pages/viewpage.action?pageId=24772914).
-If you have any questions, you can reach us on
-[Hyperledger Besu chat](https://discord.gg/hyperledger).
+If you have any questions, you can reach us on the
+[Besu channel on Hyperledger Discord](https://discord.gg/hyperledger).

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This repository only contains the sources for
 * How to contribute to the
   [Besu codebase](https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md).
 
-## Linux Foundation / GitHub accounts
+## GitHub/Discord/Linux Foundation accounts
 
 Having the following accounts is necessary for contributing code/issues to Besu:
 
 * If you want to contribute code, create a [Linux Foundation (LF) account] and a [GitHub account].
 * If you want to raise an issue, login to your [GitHub account].
-* [Discord] also requires a Discord account.
+* [Hyperledger Discord] also requires a Discord account.
 
 <!-- Links -->
 [Besu User Documentation]: https://besu.hyperledger.org

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Having the following accounts is necessary for contributing code/issues to Besu:
 
 * If you want to contribute code, create a [Linux Foundation (LF) account] and a [GitHub account].
 * If you want to raise an issue, login to your [GitHub account].
-* [chat] also requires a Discord account.
+* [Discord] also requires a Discord account.
 
 <!-- Links -->
 [Besu User Documentation]: https://besu.hyperledger.org
 [Linux Foundation (LF) account]: https://wiki.hyperledger.org/display/CA/Setting+up+an+LFID
 [GitHub account]: https://www.github.com/
-[chat]: https://discord.gg/hyperledger
+[Hyperledger Discord]: https://discord.gg/hyperledger

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Having the following accounts is necessary for contributing code/issues to Besu:
 
 * If you want to contribute code, create a [Linux Foundation (LF) account] and a [GitHub account].
 * If you want to raise an issue, login to your [GitHub account].
-* [chat] also requires a [Linux Foundation (LF) account].
+* [chat] also requires a Discord account.
 
 <!-- Links -->
 [Besu User Documentation]: https://besu.hyperledger.org
 [Linux Foundation (LF) account]: https://wiki.hyperledger.org/display/CA/Setting+up+an+LFID
 [GitHub account]: https://www.github.com/
-[chat]: https://chat.hyperledger.org/
+[chat]: https://discord.gg/hyperledger

--- a/docs/Concepts/ArchitectureOverview.md
+++ b/docs/Concepts/ArchitectureOverview.md
@@ -9,4 +9,4 @@ The following diagram outlines the Hyperledger Besu high-level architecture.
 ![Architecture](../images/Architecture.png)
 
 For more information about the Hyperledger Besu architecture, contact us on
-[Hyperledger Besu chat](https://chat.hyperledger.org/channel/besu).
+[Hyperledger Besu chat](https://discord.gg/hyperledger).

--- a/docs/Concepts/ArchitectureOverview.md
+++ b/docs/Concepts/ArchitectureOverview.md
@@ -8,5 +8,5 @@ The following diagram outlines the Hyperledger Besu high-level architecture.
 
 ![Architecture](../images/Architecture.png)
 
-For more information about the Hyperledger Besu architecture, contact us on
-[Hyperledger Besu chat](https://discord.gg/hyperledger).
+For more information about the Hyperledger Besu architecture, contact us on the
+[Besu channel on Hyperledger Discord](https://discord.gg/hyperledger).

--- a/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
+++ b/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
@@ -22,7 +22,7 @@ The following documentation explains [the transaction lifecycle] in GoQuorum-com
 !!! note
 
     If you intend to use this privacy mode for a production use case, please contact us on
-    [Rocket Chat](https://chat.hyperledger.org/channel/besu) or by [email](mailto:besu@lists.hyperledger.org).
+    [Hyperledger Besu Chat](https://discord.gg/hyperledger) or by [email](mailto:besu@lists.hyperledger.org).
 
 <!--links-->
 [GoQuorum clients]: https://docs.goquorum.consensys.net/

--- a/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
+++ b/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
@@ -21,8 +21,8 @@ The following documentation explains [the transaction lifecycle] in GoQuorum-com
 
 !!! note
 
-    If you intend to use this privacy mode for a production use case, please contact us on
-    [Hyperledger Besu Chat](https://discord.gg/hyperledger) or by [email](mailto:besu@lists.hyperledger.org).
+    If you intend to use this privacy mode for a production use case, please contact us on the
+    [Besu channel on Hyperledger Discord](https://discord.gg/hyperledger) or by [email](mailto:besu@lists.hyperledger.org).
 
 <!--links-->
 [GoQuorum clients]: https://docs.goquorum.consensys.net/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ extra:
     some displayed features may not be available in the stable release.
     You can switch to stable version using the version box at screen bottom.'
   support:
-    chat: https://discord.gg/hyperledger
+    community: https://discord.gg/hyperledger
     email: besu@lists.hyperledger.org
     website: https://www.hyperledger.org/projects/besu
     issues: https://github.com/hyperledger/besu/issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ extra:
     some displayed features may not be available in the stable release.
     You can switch to stable version using the version box at screen bottom.'
   support:
-    community: https://discord.gg/hyperledger
+    chat: https://discord.gg/hyperledger
     email: besu@lists.hyperledger.org
     website: https://www.hyperledger.org/projects/besu
     issues: https://github.com/hyperledger/besu/issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ extra:
     some displayed features may not be available in the stable release.
     You can switch to stable version using the version box at screen bottom.'
   support:
-    chat: https://chat.hyperledger.org/channel/besu
+    chat: https://discord.gg/hyperledger
     email: besu@lists.hyperledger.org
     website: https://www.hyperledger.org/projects/besu
     issues: https://github.com/hyperledger/besu/issues


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>
Replace chat links with Discord link. 
I used the same link everywhere which is fine unless it's helpful to link directly to the besu channel

Fixes #947 
### For content changes

- [x] Doc content
- [ ] Doc pages organisation