### PR TITLE
Update GoQuorum links to new repository

### DIFF
--- a/docs/HowTo/Configure/Consensus-Protocols/QBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/QBFT.md
@@ -558,5 +558,5 @@ To swap between block header validator selection and contract validator selectio
 *[vanity data]: Validators can include anything they like as vanity data.
 *[RLP]: Recursive Length Prefix
 
-[GoQuorum]: https://docs.goquorum.consensys.net/en/stable/
+[GoQuorum]: https://consensys.net/docs/goquorum/en/stable/
 [View the example smart contract]: https://github.com/ConsenSys/validator-smart-contracts

--- a/docs/HowTo/Configure/Consensus-Protocols/QuorumIBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/QuorumIBFT.md
@@ -9,7 +9,7 @@ Besu nodes can operate (that is, submit transactions and receive blocks) in a Qu
 
 To connect to a Quorum IBFT 1.0 network:
 
-1. In the [Quorum IBFT 1.0 genesis file](https://docs.goquorum.consensys.net/en/stable/HowTo/Configure/Consensus-Protocols/IBFT/#genesis-file):
+1. In the [Quorum IBFT 1.0 genesis file](https://consensys.net/docs/goquorum/en/stable/configure-and-manage/configure/consensus-protocols/ibft/#genesis-file):
 
     - Update the consensus protocol specified in the `config` item from `istanbul` to `ibft`.
     - In the `ibft` item:

--- a/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
+++ b/docs/HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md
@@ -25,6 +25,6 @@ The following documentation explains [the transaction lifecycle] in GoQuorum-com
     [Besu channel on Hyperledger Discord](https://discord.gg/hyperledger) or by [email](mailto:besu@lists.hyperledger.org).
 
 <!--links-->
-[GoQuorum clients]: https://docs.goquorum.consensys.net/
+[GoQuorum clients]: https://consensys.net/docs/goquorum/en/stable/
 [QBFT]: ../Configure/Consensus-Protocols/QBFT.md
-[the transaction lifecycle]: https://docs.goquorum.consensys.net/Concepts/Privacy/PrivateTransactionLifecycle/
+[the transaction lifecycle]: https://consensys.net/docs/goquorum/en/stable/concepts/privacy/private-transaction-lifecycle/

--- a/docs/Reference/Config-Items.md
+++ b/docs/Reference/Config-Items.md
@@ -143,5 +143,5 @@ Anything listed in the configuration file also takes precedence.
     ```
 
 <!--links-->
-[GoQuorum clients]: https://docs.goquorum.consensys.net/
+[GoQuorum clients]: https://consensys.net/docs/goquorum/en/stable/
 [interoperable private transactions]: ../HowTo/Use-Privacy/Use-GoQuorum-compatible-privacy.md


### PR DESCRIPTION
Signed-off-by: Roland Tyler <roland.tyler@consensys.net>

## Describe the change
Update remaining links to new GoQuorum repository
<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed
Fixes #951 
<!-- Except for minor changes (typos, commas) it's required to have a Github issue linked to your
pull request.

Use the following to make Github close the issue automatically when merging the PR:
fixes #{your issue number}
If multiple issues are involved, use one line for each issue.

If you don't want to close the issue, use:
see #{your issue number} -->

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->
