### PR TITLE
[MINOR] delete spurious comma

### DIFF
--- a/docs/Tutorials/Private-Network/Create-Private-Clique-Network.md
+++ b/docs/Tutorials/Private-Network/Create-Private-Clique-Network.md
@@ -107,7 +107,7 @@ Copy the following genesis definition to a file called `cliqueGenesis.json` and 
         "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
         "balance": "90000000000000000000000"
       }
-   },
+   }
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Removed extra comma in genesis file example

- [x] Doc content
- [ ] Doc pages organisation