### PR TITLE
Remove caution about not being able to change the miningbeneficiary in a running network for BFT

### DIFF
--- a/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/IBFT.md
@@ -88,8 +88,6 @@ The properties specific to IBFT 2.0 are:
 
 !!! caution
 
-    The `miningbeneficiary` property cannot be updated once your network is started.
-
     We do not recommend changing `epochlength` in a running network. Changing the `epochlength`
     after genesis can result in illegal blocks.
 

--- a/docs/HowTo/Configure/Consensus-Protocols/QBFT.md
+++ b/docs/HowTo/Configure/Consensus-Protocols/QBFT.md
@@ -201,8 +201,6 @@ The QBFT properties are:
 
 !!! caution
 
-    The `miningbeneficiary` property cannot be updated once your network is started.
-
     We do not recommend changing `epochlength` in a running network. Changing the `epochlength`
     after genesis can result in illegal blocks.
 


### PR DESCRIPTION
Following https://github.com/hyperledger/besu-docs/pull/973

Make sure that:

- [x] [all commits in this PR are signed off for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] you read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Contributing+to+documentation).
- [x] you have [tested your changes locally](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewTheDocumentation) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [x] you fixed all the issues raised by the tests, if any.
- [x] you verified the rendering of your changes on [ReadTheDocs.org PR preview](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewwithReadTheDocs)
  and updated the testing link (see [Testing](#testing)).

### For content changes

- [x] Doc content
- [ ] Doc pages organisation

## Testing

<!-- Steps to follow to review and test your changes.
Add links to preview the pages changes here.
Link format is https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/
Where {your PR number} must be replaced by the number of this PR, for instance 123
-->
https://hyperledger-besu--988.org.readthedocs.build/en/988/HowTo/Configure/Consensus-Protocols/QBFT/#genesis-file
https://hyperledger-besu--988.org.readthedocs.build/en/988/HowTo/Configure/Consensus-Protocols/IBFT/#genesis-file