### PR TITLE
fix jinja2 incompatible update

### DIFF
--- a/CI/requirements.txt
+++ b/CI/requirements.txt
@@ -9,3 +9,5 @@ mkdocs-redirects==1.0.0
 mkdocs-git-revision-date-localized-plugin==0.5.0
 # mkdocs-minify-plugin==0.3.0
 plantuml-markdown==3.3.0
+jinja2==3.0.0
+


### PR DESCRIPTION
## Pull request checklist

Use the following list to make sure your PR fits the Besu doc quality standard.

### Before creating the pull request

Make sure that:

- [x] [all commits in this PR are signed off for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] you read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Contributing+to+documentation).
- [x] you have [tested your changes locally](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewTheDocumentation) before submitting them to the community for review.

### After creating your pull request and tests finished

Make sure that:

- [ ] you fixed all the issues raised by the tests, if any.
- [ ] you verified the rendering of your changes on [ReadTheDocs.org PR preview](https://wiki.hyperledger.org/display/BESU/MkDocs+And+Markdown+Guide#MkDocsAndMarkdownGuide-PreviewwithReadTheDocs)
  and updated the testing link (see [Testing](#testing)).

## Describe the change

Add jinja2 dep explicitely in the requirement file as the way the dep is defined in MkDocs Material allows its update and fails because the new 3.1.0 version is incompatible. So it freezes to version 3.0.0

<!-- A clear and concise description of what this PR changes in the documentation. -->

## Issue fixed

All builds failing

## Impacted parts <!-- check as many boxes as needed -->

### For content changes

- [ ] Doc content
- [ ] Doc pages organisation

### For tools changes

- [ ] CircleCI workflow
- [ ] Build and QA tools (lint, vale,…)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [x] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] ReadTheDocs configuration
- [ ] GitHub integration