### PR TITLE
clears up some misconception about JWTs

### DIFF
--- a/docs/public-networks/how-to/prepare-for-the-merge.md
+++ b/docs/public-networks/how-to/prepare-for-the-merge.md
@@ -43,19 +43,22 @@ configuration file.
 ### 2. Configure the JSON Web Token
 
 JSON Web Token (JWT) authentication is used to secure the Engine API.
-You can generate a JWT using a command line tool, for example:
+You can generate a key for signing JWTs using a command line tool, for example:
 
 ```bash
 openssl rand -hex 32 -out <file>
 ```
 
-Provide the JWT to Besu using the [`engine-jwt-secret`](../reference/cli/options.md#engine-jwt-secret)
+Provide the signing key to Besu using the [`engine-jwt-secret`](../reference/cli/options.md#engine-jwt-secret)
 configuration option, and to the consensus client using its configuration options.
-For example, provide the JWT to [Teku] using the
+For example, provide the key to [Teku] using the
 [`ee-jwt-secret-file`](https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#ee-jwt-secret-file) option.
 
-If you don't provide a token to Besu, Besu will automatically generate a new token called `jwt.hex` and store it in the
+If you don't provide a key to Besu, Besu will automatically generate a new key called `jwt.hex` and store it in the
 configured data directory.
+
+This key is used by the consensus client to sign JWT tokens it generates to authenticate to the
+Engine API. Besu uses the same key to validate the token presented.
 
 ### 3. Sync Besu
 


### PR DESCRIPTION
Clarifies the difference between JWTs and the key used to sign and validate them.

Signed-off-by: Justin Florentine <justin+github@florentine.us>

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [X] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] CircleCI workflow
- [ ] Build and QA tools (for example, lint or vale)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've fixed any issues raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation)
  and added a [preview link](#preview).

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
