### PR TITLE
Update estimated storage requirements

### DIFF
--- a/docs/public-networks/concepts/data-storage-formats.md
+++ b/docs/public-networks/concepts/data-storage-formats.md
@@ -57,8 +57,8 @@ To run a node with Bonsai Tries data storage format, use the command line option
 Forest mode uses significantly more memory than Bonsai.
 With an [archive node](../how-to/connect/sync-node.md#run-an-archive-node), forest mode uses an estimated 12 TB of
 storage, while Bonsai uses an estimated 1100 GB of storage.
-With a [full node](../how-to/connect/sync-node.md#run-a-full-node), forest mode uses an estimated 7 TB of storage,
-while Bonsai uses an estimated 790 GB of storage.
+With a [full node](../how-to/connect/sync-node.md#run-a-full-node), forest mode uses an estimated 750 GB of storage,
+while Bonsai uses an estimated 650 GB of storage.
 
 ### Accessing data
 
@@ -83,10 +83,10 @@ storage formats using [fast](../how-to/connect/sync-node.md#fast-synchronization
 
 | Data storage format | Sync mode | Storage estimate | Can other nodes sync to your node? |
 |---------------------|-----------|------------------|------------------------------------|
-| Bonsai              | Fast      | 790 GB           | No                                 |
-| Bonsai              | Snap      | 790 GB           | To be implemented                  |
-| Forest              | Fast      | 7 TB             | Yes                                |
-| Forest              | Snap      | 7 TB             | To be implemented                  |
+| Bonsai              | Fast      | 650 GB           | No                                 |
+| Bonsai              | Snap      | 650 GB           | To be implemented                  |
+| Forest              | Fast      | 750 GB           | Yes                                |
+| Forest              | Snap      | 750 GB           | To be implemented                  |
 
 !!! important
 


### PR DESCRIPTION
The documented storage requirements for a **full node** are incorrect.

I recently started my Besu experience by running a BONSAI node that unfortunately failed after The Merge, but its storage usage was just under 650GB when it was fully synced pre-merge (Linux, XFS filesystem)

I then synced using FOREST mode and was expecting 7TB of usage but it turned out to only be about 750GB. After speaking with @NicolasMassart (0x6E69636F#2619 on Discord) I was informed that the docs were wrong.

Please re-validate these numbers if you can. I have not had the time to run full Archive nodes to check those storage requirements, but they're likely correct.