### PR TITLE
Remove deprecated `--Xmerge-support` CLI option.

### DIFF
--- a/docs/public-networks/get-started/connect/mainnet.md
+++ b/docs/public-networks/get-started/connect/mainnet.md
@@ -51,7 +51,6 @@ besu \
   --rpc-ws-host=0.0.0.0        \
   --host-allowlist=<IP of Besu node>,127.0.0.1,localhost        \
   --engine-host-allowlist=<IP of Besu node>,127.0.0.1,localhost \
-  --Xmerge-support=true        \
   --engine-jwt-secret=<path to jwtsecret.hex>
 ```
 
@@ -75,7 +74,6 @@ Also, in the command:
   service.
 - [`--rpc-ws-host`](../../reference/cli/options.md#rpc-ws-host) is set to `0.0.0.0` to allow remote
   RPC connections.
-- `--Xmerge-support` enables Merge support.
 
 You can modify the option values and add other [command line options](../../reference/cli/options.md)
 as needed.

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -54,7 +54,6 @@ Run the following command or specify the options in a
       --rpc-ws-host=0.0.0.0       \
       --host-allowlist="*"        \
       --engine-host-allowlist="*" \
-      --Xmerge-support=true       \
       --engine-jwt-secret=<path to jwtsecret.hex>
     ```
 
@@ -70,7 +69,6 @@ Run the following command or specify the options in a
       --rpc-ws-host=0.0.0.0       \
       --host-allowlist="*"        \
       --engine-host-allowlist="*" \
-      --Xmerge-support=true       \
       --engine-jwt-secret=<path to jwtsecret.hex>
     ```
 

--- a/docs/public-networks/tutorials/besu-teku-mainnet.md
+++ b/docs/public-networks/tutorials/besu-teku-mainnet.md
@@ -44,7 +44,6 @@ besu \
   --rpc-ws-host="0.0.0.0"      \
   --host-allowlist=<IP of Besu node>,127.0.0.1,localhost        \
   --engine-host-allowlist=<IP of Besu node>,127.0.0.1,localhost \
-  --Xmerge-support=true        \
   --engine-jwt-secret=<path to jwtsecret.hex>
 ```
 
@@ -67,7 +66,6 @@ Also, in the command:
   service.
 - [`--rpc-ws-host`](../reference/cli/options.md#rpc-ws-host) is set to `0.0.0.0` to allow remote RPC
   connections.
-- `--Xmerge-support` enables Merge support.
 
 You can modify the option values and add other [command line options](../reference/cli/options.md)
 as needed.

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -54,7 +54,6 @@ Run the following command or specify the options in a [configuration file](../ho
       --rpc-ws-host=0.0.0.0       \
       --host-allowlist="*"        \
       --engine-host-allowlist="*" \
-      --Xmerge-support=true       \
       --engine-jwt-secret=<path to jwtsecret.hex>
     ```
 
@@ -70,7 +69,6 @@ Run the following command or specify the options in a [configuration file](../ho
       --rpc-ws-host=0.0.0.0       \
       --host-allowlist="*"        \
       --engine-host-allowlist="*" \
-      --Xmerge-support=true       \
       --engine-jwt-secret=<path to jwtsecret.hex>
     ```
 


### PR DESCRIPTION
Signed-off-by: bgravenorst <byron.gravenorst@consensys.net>

## Pull request checklist

Use the following list to make sure your PR fits the Besu documentation quality standard.

### Before creating the pull request

Make sure that:

- [x] [All commits in this PR are signed off for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] You've read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] You've [previewed your changes locally](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation).

## Describe the change

Removed the deprecated `--Xmerge-support` CLI option.

## Issue fixed

Fixes #1196 

## Preview
https://hyperledger-besu--1197.org.readthedocs.build/en/1197/

