### PR TITLE
Updating public network info for sync 

### DIFF
--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -46,7 +46,7 @@ All times are hardware dependent. We tabulate these running AWS instances m6gd.2
 | Fast        | ~1.5 days   | Average Disk |
 | Full        | ~weeks      | Most Disk Usage | 
    
-As of late 2022, an average Mainnet Snap Sync will consume around ~650GB on Bonsai. While the worldstate is syncing, Besu will download and import the blockchain in the background. It will need to catch up to the current chain head and sync the worldstate to participate on Mainnet. 
+As of late 2022, an average Mainnet Snap Sync will consume around ~750GB on Bonsai. While the worldstate is syncing, Besu will download and import the blockchain in the background. It will need to catch up to the current chain head and sync the worldstate to participate on Mainnet. 
 
 ### Snap synchronization
 

--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -76,11 +76,11 @@ You can't switch from fast sync to snap sync.
 If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node,
 deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
 
-See [how to read the Besu metrics charts](../../how-to/monitor/understand-metrics.md) when using snap sync.
-
 You can restart Besu during a snap sync in case of hardware or software problems.
 The sync resumes from the last valid world state and continues to download blocks starting from the
 last downloaded block.
+
+See [how to read the Besu metrics charts](../../how-to/monitor/understand-metrics.md) when using snap sync.
 
 ### Checkpoint synchronization
 
@@ -110,10 +110,6 @@ number, and total difficulty as in the following example.
       "totalDifficulty": "0xA2539264C62BF98CFC6"
     }
     ```
-You can restart Besu during a checkpoint sync in case of hardware or software problems.
-The sync resumes from the last valid world state and continues to download blocks starting from the
-last downloaded block.
-
 
 !!! note
 
@@ -122,6 +118,10 @@ last downloaded block.
 
 If you enable checkpoint sync without a checkpoint configuration in the genesis file, Besu snap
 syncs from the genesis block.
+
+You can restart Besu during a checkpoint sync in case of hardware or software problems.
+The sync resumes from the last valid world state and continues to download blocks starting from the
+last downloaded block.
 
 ### Fast synchronization
 

--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -4,26 +4,49 @@ description: Full and archive node types
 
 # Sync Besu
 
-Besu supports two node types, commonly referred to as _full nodes_ and _archive nodes_.
+Besu supports two node types, commonly referred to as [full nodes](#run-a-full-node) and
+[archive nodes](#run-an-archive-node).
 
-Full nodes have the current state of the blockchain so cannot serve the network with all data
-requests (for example, the balance of an account at an old block). Full nodes can guarantee the
-latest state for the blockchain (and some older states, but not all). You can check current
-balances, sign and send transactions, and look at current dapp data.
+Full nodes have the current state of the blockchain.
+They can't serve the network with all data requests (for example, the balance of an account at an
+old block).
+Full nodes can guarantee the latest state for the blockchain (and some older states, but not all).
+You can check current balances, sign and send transactions, and look at current dapp data.
 
-Archive nodes have all of this and they also store the intermediary state of every account and
-contract for every block since the genesis block. An archive node can do everything a full node
-does, and it can access historical state data.
+Archive nodes also store the intermediary state of every account and contract for every block since
+the genesis block.
+Archive nodes can do everything full nodes do, and they can access historical state data.
+Archive nodes require more disk space than full nodes.
 
-For Besu on Mainnet, archive nodes [require more disk space](../../concepts/data-storage-formats.md#storage-requirements)
-than full nodes.
+## Sync times
+
+To sync with a public network, Besu runs two processes in parallel: the world state sync and the
+blockchain download.
+
+The following table shows the average world state sync time for each sync mode.
+All times are hardware dependent; this table is based on running AWS instances m6gd.2xlarge.
+Each sync mode also has its own world state database size.
+
+| Sync mode   | Time to sync world state | Disk usage    |
+| ----------- | ------------------------ | ------------- |
+| Snap        | ~6 hours                 | Average disk  |
+| Checkpoint  | ~5 hours                 | Smallest disk |
+| Fast        | ~1.5 days                | Average disk  |
+| Full        | ~weeks                   | Largest disk  |
 
 !!! note
 
-    Besu running on other public testnets and other Ethereum clients have
-    different disk space requirements.
+    As of late 2022, an average Mainnet snap sync consumes around 750 GB using Bonsai Tries.
+    Read more about [storage requirements](../../concepts/data-storage-formats.md#storage-requirements)
+    across data storage formats and sync modes.
 
-## Store data
+While the world state syncs, Besu downloads and imports the blockchain in the background.
+The blockchain download time depends on CPU, the network, Besu's peers, and disk speed.
+It generally takes longer than the world state sync.
+
+Besu must catch up to the current chain head and sync the world state to participate on Mainnet.
+
+## Storage
 
 You can store the world state using [Forest of Tries](../../concepts/data-storage-formats.md#forest-of-tries)
 or [Bonsai Tries](../../concepts/data-storage-formats.md#bonsai-tries).
@@ -31,31 +54,15 @@ We recommend using Bonsai Tries for the lowest storage requirements.
 
 ## Run a full node
 
-You can run a full node using [fast synchronization (fast sync)](#fast-synchronization),
-[snap synchronization (snap sync)](#snap-synchronization), or
-[checkpoint synchronization (checkpoint sync)](#checkpoint-synchronization).
-
-To bring Besu in sync with a public network, it runs two processes in parallel. These are the worldstate download and the blockchain download. Average worldstate sync times are below. The blockchain download is largely dependent upon CPU, your network, Besu's peers, and disk speed. While we do not provide those estimates, expect it to take longer than the worldstate sync. Each sync mode will also have a differnet sized worldstate database.
-
-All times are hardware dependent. We tabulate these running AWS instances m6gd.2xlarge.
-
-| Sync Mode      | Time to Sync Worldstate | Disk Usage |
-| ----------- | ----------- | ----------- |
-| Snap        | ~6 hours    | Average Disk |
-| Checkpoint  | ~5 hours    | Smallest Disk |
-| Fast        | ~1.5 days   | Average Disk |
-| Full        | ~weeks      | Most Disk Usage | 
-   
-As of late 2022, an average Mainnet Snap Sync will consume around ~750GB on Bonsai. While the worldstate is syncing, Besu will download and import the blockchain in the background. It will need to catch up to the current chain head and sync the worldstate to participate on Mainnet. 
+You can run a full node using [snap synchronization (snap sync)](#snap-synchronization),
+[checkpoint synchronization (checkpoint sync)](#checkpoint-synchronization), or
+[fast synchronization (fast sync)](#fast-synchronization).
 
 ### Snap synchronization
 
 !!! important
 
-    We recommend using snap sync over fast sync even in certain production environments (for example, staking),
-    because snap sync can be faster by several days.
-    If your snap sync completes successfully, you have the correct world state.
-
+    We recommend using snap sync over fast sync because snap sync can be faster by several days.
     We recommend using snap sync with the [Bonsai](../../concepts/data-storage-formats.md#bonsai-tries)
     data storage format for the fastest sync and lowest storage requirements.
 
@@ -71,7 +78,9 @@ deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
 
 See [how to read the Besu metrics charts](../../how-to/monitor/understand-metrics.md) when using snap sync.
 
-Besu can be restarted during a Snap Sync in case of hardware or software problems. It will resume from the last valid worldstate and will continue to download blocks starting from its last downloaded block. 
+You can restart Besu during a snap sync in case of hardware or software problems.
+The sync resumes from the last valid world state and continues to download blocks starting from the
+last downloaded block.
 
 ### Checkpoint synchronization
 
@@ -101,7 +110,9 @@ number, and total difficulty as in the following example.
       "totalDifficulty": "0xA2539264C62BF98CFC6"
     }
     ```
-Besu can be restarted during a Checkpoint Sync in case of hardware or software problems. It will resume from the last valid worldstate and will continue to download blocks starting from its last downloaded block. 
+You can restart Besu during a checkpoint sync in case of hardware or software problems.
+The sync resumes from the last valid world state and continues to download blocks starting from the
+last downloaded block.
 
 
 !!! note
@@ -109,22 +120,15 @@ Besu can be restarted during a Checkpoint Sync in case of hardware or software p
     If using [Clique](../../../private-networks/how-to/configure/consensus/clique.md) consensus, the
     checkpoint must be the beginning of an epoch.
 
-If you enable checkpoint sync without a checkpoint configuration in the genesis file, Besu will snap
-sync from the genesis block.
-
-## Run an archive node
-
-To run an archive node, enable full synchronization (full sync) using
-[`--sync-mode=FULL`](../../reference/cli/options.md#sync-mode).
-
-Full sync starts from the genesis block and reprocesses all transactions.
+If you enable checkpoint sync without a checkpoint configuration in the genesis file, Besu snap
+syncs from the genesis block.
 
 ### Fast synchronization
 
-!!! note
- 
-    It may become impossible to sync Ethereum Mainnet with 
-    Fast sync in the future. Make sure to update Besu to a version that supports newer sync methods.
+!!! important
+
+    It might become impossible to sync Ethereum Mainnet using fast sync in the future.
+    Update Besu to a version that supports newer sync methods.
 
 Enable fast sync using [`--sync-mode=FAST`](../../reference/cli/options.md#sync-mode).
 
@@ -185,3 +189,10 @@ You can observe the `besu_synchronizer_fast_sync_*` and `besu_synchronizer_world
     ![Fast synchronization](../../../assets/images/fastsync.png)
 
     The easiest solution in this scenario is to restart fast sync to obtain a new pivot block.
+
+## Run an archive node
+
+To run an archive node, enable full synchronization (full sync) using
+[`--sync-mode=FULL`](../../reference/cli/options.md#sync-mode).
+
+Full sync starts from the genesis block and reprocesses all transactions.

--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -23,7 +23,7 @@ Archive nodes require more disk space than full nodes.
 To sync with a public network, Besu runs two processes in parallel: the world state sync and the
 blockchain download.
 
-The following table shows the average world state sync time for each sync mode.
+The following table shows the average world state sync time for each sync mode on Mainnet.
 All times are hardware dependent; this table is based on running AWS instances m6gd.2xlarge.
 Each sync mode also has its own world state database size.
 
@@ -36,9 +36,11 @@ Each sync mode also has its own world state database size.
 
 !!! note
 
-    As of late 2022, an average Mainnet snap sync consumes around 750 GB using Bonsai Tries.
-    Read more about [storage requirements](../../concepts/data-storage-formats.md#storage-requirements)
-    across data storage formats and sync modes.
+    - As of late 2022, an average Mainnet snap sync consumes around 750 GB using Bonsai Tries.
+      Read more about [storage requirements](../../concepts/data-storage-formats.md#storage-requirements)
+      across data storage formats and sync modes.
+
+    - Testnets take significantly less time and space to sync.
 
 While the world state syncs, Besu downloads and imports the blockchain in the background.
 The blockchain download time depends on CPU, the network, Besu's peers, and disk speed.
@@ -128,7 +130,8 @@ last downloaded block.
 !!! important
 
     It might become impossible to sync Ethereum Mainnet using fast sync in the future.
-    Update Besu to a version that supports newer sync methods.
+    If you sync for the first time or ever need to re-sync, update Besu to a version that supports
+    newer sync methods.
 
 Enable fast sync using [`--sync-mode=FAST`](../../reference/cli/options.md#sync-mode).
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -3210,10 +3210,10 @@ The default is `false`.
     ```
 
 The synchronization mode.
-Use `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), `FULL` for
-[full sync](../../get-started/connect/sync-node.md#run-an-archive-node), `X_SNAP` for
-[snap sync](../../get-started/connect/sync-node.md#snap-synchronization), and `X_CHECKPOINT` for
-[checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization).
+Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization),
+`X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization),
+`FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for
+[full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 * The default is `FULL` when connecting to a private network by not using the [`--network`](#network)
   option and specifying the [`--genesis-file`](#genesis-file) option.
@@ -3224,11 +3224,10 @@ Use `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchroni
 
 !!! important
 
-    Snap sync and checkpoint sync are early access features.
-
-    We recommend using snap sync over fast sync even in certain production environments (for example, staking), because
-    snap sync can be faster by several days.
-    If your snap sync completes successfully, you have the correct world state.
+    * We recommend using snap sync over fast sync because snap sync can be faster by several days.
+    * Checkpoint sync is an early access feature.
+    * It might become impossible to sync Ethereum Mainnet using fast sync in the future.
+      Update Besu to a version that supports newer sync methods.
 
 ### `target-gas-limit`
 


### PR DESCRIPTION
Added time and size estimates. Removed warning on snap sync restarts (besu now resumes from last point). Moved fast sync to the bottom and added not on deprecation on Mainnet. 

Signed-off-by: Matt Nelson <85905982+non-fungible-nelson@users.noreply.github.com>