### PR TITLE
Update fast-sync-min-peers description

### DIFF
--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -268,7 +268,6 @@ The block parameter can have the following values:
   honest majority and certain synchronicity assumptions.
 
 !!! note
-
-    If [synchronizing in FAST mode](../../reference/cli/options.md#sync-mode), most
+    When [synchronizing a full node](../../get-started/connect/sync-node.md#run-a-full-node), most
     historical world state data is unavailable. Any methods attempting to access unavailable world
     state data return `null`.

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -266,8 +266,3 @@ The block parameter can have the following values:
   It cannot be reorganized outside manual intervention driven by community coordination.
 * `safe` : `tag` - The most recent block that is safe from reorganization under
   honest majority and certain synchronicity assumptions.
-
-!!! note
-    When [synchronizing a full node](../../get-started/connect/sync-node.md#run-a-full-node), most
-    historical world state data is unavailable. Any methods attempting to access unavailable world
-    state data return `null`.

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -724,22 +724,15 @@ Contact email address to send to the Ethstats server specified by [`--ethstats`]
     fast-sync-min-peers=8
     ```
 
-The minimum number of peers required before starting [fast synchronization](../../get-started/connect/sync-node.md#fast-synchronization).
+The minimum number of peers required before starting [fast synchronization](../../get-started/connect/sync-node.md#fast-synchronization)
+in [proof of work](../../how-to/use-pow/mining.md) networks.
 The default is 1.
 
-!!! note
+!!! important
 
-    If synchronizing in `FAST` mode, most historical world state data is unavailable. Any methods
-    attempting to access unavailable world state data return `null`.
+    This option only applies to proof of work networks.
 
 ### `genesis-file`
-
-Use the genesis file to create a custom network.
-
-!!!tip
-
-    To use a public Ethereum network such as Goerli, use the [`--network`](#network) option. The
-    network option defines the genesis file for public networks.
 
 === "Syntax"
 
@@ -765,11 +758,11 @@ Use the genesis file to create a custom network.
     genesis-file="/home/me/me_node/customGenesisFile.json"
     ```
 
-The path to the genesis file.
+The path to the [genesis file](../../concepts/genesis-file.md).
 
 !!!important
 
-    You cannot use the [`--genesis-file`](#genesis-file) and [`--network`](#network) options at the
+    You can't use the [`--genesis-file`](#genesis-file) and [`--network`](#network) options at the
     same time.
 
 ### `graphql-http-cors-origins`

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -726,7 +726,7 @@ Contact email address to send to the Ethstats server specified by [`--ethstats`]
 
 The minimum number of peers required before starting [fast synchronization](../../get-started/connect/sync-node.md#fast-synchronization)
 in [proof of work](../../how-to/use-pow/mining.md) networks.
-The default is 1.
+The default is 5.
 
 !!! important
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -3221,6 +3221,8 @@ Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchro
     * Checkpoint sync is an early access feature.
     * It might become impossible to sync Ethereum Mainnet using fast sync in the future.
       Update Besu to a version that supports newer sync methods.
+    * When synchronizing in a mode other than `FULL`, most historical world state data is unavailable.
+      Any methods attempting to access unavailable world state data return `null`.
 
 ### `target-gas-limit`
 


### PR DESCRIPTION
Update `fast-sync-min-peers` description to note that it only applies to PoW networks. Also fix the the `genesis-file` option description right after it.

Fixes #1192.