### PR TITLE
Add `shandong` to network list

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -1705,7 +1705,7 @@ Possible values are:
 | `mainnet`  | ETH   | Production  | [FAST](#sync-mode) | The main network                                               |
 | `goerli`   | ETH   | Test        | [FAST](#sync-mode) | A PoA network using Clique                                     |
 | `sepolia`  | ETH   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
-| `shandong` | ETH   | Test        | [FAST](#sync-mode) | An experimental network for testing the [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md) network upgrade. |
+| `shandong` | ETH   | Test        | [FAST](#sync-mode) | An experimental network for testing the [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md) network upgrade |
 | `dev`      | ETH   | Development | [FULL](#sync-mode) | A PoW network with a low difficulty to enable local CPU mining |
 | `classic`  | ETC   | Production  | [FAST](#sync-mode) | The main Ethereum Classic network                              |
 | `mordor `  | ETC   | Test        | [FAST](#sync-mode) | A PoW network                                                  |

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -1707,16 +1707,17 @@ The default is `mainnet`.
 
 Possible values are:
 
-| Network   | Chain | Type        | Default Sync Mode  | Description                                                    |
-|:----------|:------|:------------|:-------------------|:---------------------------------------------------------------|
-| `mainnet` | ETH   | Production  | [FAST](#sync-mode) | The main network                                               |
-| `goerli`  | ETH   | Test        | [FAST](#sync-mode) | A PoA network using Clique                                     |
-| `sepolia` | ETH   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
-| `dev`     | ETH   | Development | [FULL](#sync-mode) | A PoW network with a low difficulty to enable local CPU mining |
-| `classic` | ETC   | Production  | [FAST](#sync-mode) | The main Ethereum Classic network                              |
-| `mordor ` | ETC   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
-| `kotti`   | ETC   | Test        | [FAST](#sync-mode) | A PoA network using Clique                                     |
-| `astor`   | ETC   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
+| Network    | Chain | Type        | Default Sync Mode  | Description                                                    |
+|:-----------|:------|:------------|:-------------------|:---------------------------------------------------------------|
+| `mainnet`  | ETH   | Production  | [FAST](#sync-mode) | The main network                                               |
+| `goerli`   | ETH   | Test        | [FAST](#sync-mode) | A PoA network using Clique                                     |
+| `sepolia`  | ETH   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
+| `shandong` | ETH   | Test        | [FAST](#sync-mode) | An experimental network for testing the [Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md) network upgrade. |
+| `dev`      | ETH   | Development | [FULL](#sync-mode) | A PoW network with a low difficulty to enable local CPU mining |
+| `classic`  | ETC   | Production  | [FAST](#sync-mode) | The main Ethereum Classic network                              |
+| `mordor `  | ETC   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
+| `kotti`    | ETC   | Test        | [FAST](#sync-mode) | A PoA network using Clique                                     |
+| `astor`    | ETC   | Test        | [FAST](#sync-mode) | A PoW network                                                  |
 
 !!! tip
 


### PR DESCRIPTION
Add Shandong testnet to list of `network` options. Fixes #1203.