### PR TITLE
Document `--rpc-max-logs-range`

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -2641,7 +2641,7 @@ command line option at the default value of `true` to improve log retrieval perf
 
 !!! important
     Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
-    its genesis block, may cause Besu to hang for an indeterminable amount of time while generating
+    its genesis block, might cause Besu to hang for an indeterminable amount of time while generating
     the response.
     We recommend setting a range limit using the [`--rpc-max-logs-range`](../cli/options.md#rpc-max-logs-range)
     option (or leaving it at its default value of 1000).

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -2641,7 +2641,8 @@ command line option at the default value of `true` to improve log retrieval perf
 
 !!! important
     Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
-    its genesis block, can cause Besu to hang and never return a response.
+    its genesis block, may cause Besu to hang for an indeterminable amount of time while generating
+    the response.
     We recommend setting a range limit using the [`--rpc-max-logs-range`](../cli/options.md#rpc-max-logs-range)
     option (or leaving it at its default value of 1000).
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -2637,11 +2637,11 @@ Returns an array of [logs](../../concepts/events-and-logs.md) matching a specifi
 Leave the [`--auto-log-bloom-caching-enabled`](../cli/options.md#auto-log-bloom-caching-enabled)
 command line option at the default value of `true` to improve log retrieval performance.
 
-!!! attention
-
+!!! important
     Using `eth_getLogs` to get the logs from a large range of blocks, especially an entire chain from
     its genesis block, can cause Besu to hang and never return a response.
-    We recommend splitting one large query into multiple ones for better performance.
+    We recommend setting a range limit using the [`--rpc-max-logs-range`](../cli/options.md#rpc-max-logs-range)
+    option (or leaving it at its default value of 1000).
 
 #### Parameters
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -2638,7 +2638,7 @@ Leave the [`--auto-log-bloom-caching-enabled`](../cli/options.md#auto-log-bloom-
 command line option at the default value of `true` to improve log retrieval performance.
 
 !!! important
-    Using `eth_getLogs` to get the logs from a large range of blocks, especially an entire chain from
+    Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
     its genesis block, can cause Besu to hang and never return a response.
     We recommend setting a range limit using the [`--rpc-max-logs-range`](../cli/options.md#rpc-max-logs-range)
     option (or leaving it at its default value of 1000).

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2813,8 +2813,16 @@ A list of comma-separated TLS protocols to support. The default is `DEFAULT_TLS_
     rpc-max-logs-range=500
     ```
 
-When using [`eth_getLogs`](../api/index.md#eth_getlogs), the maximum range of blocks to query.
+When using [`eth_getLogs`](../api/index.md#eth_getlogs), the maximum number of blocks to get logs
+from.
+Set to 0 to specify no limit.
 The default is 1000.
+
+!!! warning
+
+    Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
+    its genesis block, can cause Besu to hang and never return a response.
+    We recommend setting a range limit or leaving this option at its default value.
 
 ### `rpc-tx-feecap`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2814,7 +2814,7 @@ The default is 1000.
 !!! warning
 
     Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
-    its genesis block, may cause Besu to hang for an indeterminable amount of time while generating
+    its genesis block, might cause Besu to hang for an indeterminable amount of time while generating
     the response.
     We recommend setting a range limit or leaving this option at its default value.
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2806,15 +2806,16 @@ A list of comma-separated TLS protocols to support. The default is `DEFAULT_TLS_
     rpc-max-logs-range=500
     ```
 
-When using [`eth_getLogs`](../api/index.md#eth_getlogs), the maximum number of blocks to get logs
-from.
+When using [`eth_getLogs`](../api/index.md#eth_getlogs), the maximum number of blocks to retrieve
+logs from.
 Set to 0 to specify no limit.
 The default is 1000.
 
 !!! warning
 
     Using `eth_getLogs` to get logs from a large range of blocks, especially an entire chain from
-    its genesis block, can cause Besu to hang and never return a response.
+    its genesis block, may cause Besu to hang for an indeterminable amount of time while generating
+    the response.
     We recommend setting a range limit or leaving this option at its default value.
 
 ### `rpc-tx-feecap`

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2787,6 +2787,35 @@ A list of comma-separated TLS protocols to support. The default is `DEFAULT_TLS_
     The singular `--rpc-http-tls-protocol` and plural `--rpc-http-tls-protocols` are available and are two names for
     the same option.
 
+### `rpc-max-logs-range`
+
+=== "Syntax"
+
+    ```bash
+    --rpc-max-logs-range=<INTEGER>
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpc-max-logs-range=500
+    ```
+
+=== "Environment variable"
+
+    ```bash
+    BESU_RPC_MAX_LOGS_RANGE=500
+    ```
+
+=== "Configuration file"
+
+    ```bash
+    rpc-max-logs-range=500
+    ```
+
+When using [`eth_getLogs`](../api/index.md#eth_getlogs), the maximum range of blocks to query.
+The default is 1000.
+
 ### `rpc-tx-feecap`
 
 === "Syntax"


### PR DESCRIPTION
Document the `--rpc-max-logs-range` CLI option for `eth_getLogs`. Fixes #1217.