### PR TITLE
Permissioning - remove reference to the dapp

### DIFF
--- a/docs/private-networks/concepts/permissioning/onchain.md
+++ b/docs/private-networks/concepts/permissioning/onchain.md
@@ -43,7 +43,7 @@ Permissioning implements three allowlists:
     [privacy marker transactions](../privacy/private-transactions/processing.md).
 
     If using account permissioning and privacy, a signing key must be specified using the
-    [--privacy-marker-transaction-signing-key-file]
+    [`--privacy-marker-transaction-signing-key-file`](../../reference/cli/options.md#privacy-marker-transaction-signing-key-file)
     command line option and the corresponding public key
     included in the accounts allowlist.
 
@@ -72,5 +72,4 @@ bootnodes to rediscover peers.
     All bootnodes must be on the nodes allowlist.
 
 <!-- Links -->
-[--privacy-marker-transaction-signing-key-file]: ../../reference/cli/options.md#privacy-marker-transaction-signing-key-file
 [specify the permissioning contract interface]: ../../how-to/use-permissioning/onchain.md#specify-the-permissioning-contract-interface-version

--- a/docs/private-networks/concepts/permissioning/onchain.md
+++ b/docs/private-networks/concepts/permissioning/onchain.md
@@ -18,36 +18,15 @@ source, the blockchain.
 
 !!! note
 
-    The permissioning smart contracts and [permissioning management dapp] are a separate product to Hyperledger Besu,
-    located in the
-    [`ConsenSys/permissioning-smart-contracts`](https://github.com/ConsenSys/permissioning-smart-contracts) repository.
-
     Custom smart contracts and dapps can be implemented to work with onchain permissioning.
 
 ## Permissioning contracts
-
-The permissioning smart contracts provided in the
-[`ConsenSys/permissioning-smart-contracts`](https://github.com/ConsenSys/permissioning-smart-contracts) repository are:
-
-* Ingress contracts for nodes and accounts - proxy contracts defined in the genesis file to defer
-  the permissioning logic to the Node Rules and Account Rules contracts. The Ingress contracts deploy
-  to static addresses.
-* Node Rules - stores the node allowlist and node allowlist operations (for example, add and
-  remove).
-* Account Rules - stores the accounts allowlist and account allowlist operations (for example, add
-  and remove).
-* Admin - stores the list of admin accounts and admin list operations (for example, add and
-  remove). Admin accounts are stored in a single list for both nodes and accounts.
 
 !!! important
 
     The permissioning contract has multiple interfaces, and each interface maps to a specific
     version of the [Enterprise Ethereum Alliance Client Specification](https://entethalliance.org/technical-specifications/).
     Ensure that you [specify the permissioning contract interface] being used when starting Besu.
-
-## Permissioning management dapp
-
-The [permissioning management dapp] provides view and maintain access to the allowlists.
 
 ### Allowlists
 
@@ -64,7 +43,7 @@ Permissioning implements three allowlists:
     [privacy marker transactions](../privacy/private-transactions/processing.md).
 
     If using account permissioning and privacy, a signing key must be specified using the
-    [`--privacy-marker-transaction-signing-key-file`]
+    [--privacy-marker-transaction-signing-key-file]
     command line option and the corresponding public key
     included in the accounts allowlist.
 
@@ -93,6 +72,5 @@ bootnodes to rediscover peers.
     All bootnodes must be on the nodes allowlist.
 
 <!-- Links -->
-[permissioning management dapp]: ../../how-to/use-permissioning/onchain.md#deploy-the-permissioning-management-dapp
-[`--privacy-marker-transaction-signing-key-file`]: ../../reference/cli/options.md#privacy-marker-transaction-signing-key-file
+[--privacy-marker-transaction-signing-key-file]: ../../reference/cli/options.md#privacy-marker-transaction-signing-key-file
 [specify the permissioning contract interface]: ../../how-to/use-permissioning/onchain.md#specify-the-permissioning-contract-interface-version

--- a/docs/private-networks/how-to/use-permissioning/onchain.md
+++ b/docs/private-networks/how-to/use-permissioning/onchain.md
@@ -1,51 +1,11 @@
 ---
-description: Updating Hyperledger Besu onchain allowlists
+description: Use onchain permissioning allowlists
 ---
 
 # Use onchain permissioning
 
-When using [onchain permissioning](../../concepts/permissioning/onchain.md), you can update
-[nodes](#update-nodes-allowlist) and [accounts](#update-accounts-allowlist) allowlists using the
-Besu [permissioning management dapp](#deploy-the-permissioning-management-dapp).
+This page contains some extra info if you're using [onchain permissioning](../../concepts/permissioning/onchain.md).
 
-## Deploy the permissioning management dapp
-
-To deploy the permissioning management dapp for production:
-
-1. Retrieve the most recent release (tarball or zip) from the [projects release page].
-
-1. Unpack the distribution into a directory available to your Web server.
-
-1. In the root of the unpack directory, add a file called `config.json` replacing the placeholders
-    shown below.
-
-    !!! example "`config.json`"
-
-        ```json
-
-        {
-          "accountIngressAddress":  "<Address of the account ingress contract>",
-          "nodeIngressAddress": "<Address of the node ingress contract>",
-          "networkId": "<ID of your Ethereum network>"
-        }
-        ```
-
-1. On your Web server, host the contents of the directory as static files and direct root requests
-    to `index.html`.
-
-!!! note "Start a production permissioned network"
-
-    To start a production permissioned network, follow the [onchain permissioning tutorial], but don't
-    perform the steps using `yarn` to install, build, and start the development server.
-    Instead, follow the steps in this section to deploy the permissioning management dapp to your Web server.
-
-## Update nodes allowlist
-
-To add a node to the Hyperledger Besu nodes allowlist:
-
-1. On the **Nodes** tab of the permissioning management dapp, select **Add Node**.
-    The **Add Node** window displays.
-1. Enter the [enode URL](../../../public-networks/concepts/node-keys.md#enode-url) of the node you are adding and select **Add Node**.
 
 !!! tip
 
@@ -60,12 +20,6 @@ To add a node to the Hyperledger Besu nodes allowlist:
 
     If using Kubernetes, enable domain name support and use the `--Xdns-update-enabled` option to ensure that Besu can
     connect to a container after being restarted, even if the IP address of the container changes.
-
-To remove a node from the nodes allowlist:
-
-1. On the **Nodes** tab of the permissioning management dapp, hover over the row of the
-    node you are removing. A trash can displays.
-1. Select the trash can.
 
 !!! tip
 
@@ -87,24 +41,6 @@ To remove a node from the nodes allowlist:
     externally accessible address.
 
     If you change your network configuration, you may need to update the node allowlist.
-
-## Update accounts allowlist
-
-To add an account to the accounts allowlist:
-
-1. On the **Accounts** tab of the permissioning management dapp, select **Add Account**.
-    The **Add Account** window displays.
-1. Enter the account address in the **Account Address** field and select **Add Account**.
-
-To remove an account from the accounts allowlist:
-
-1. On the **Accounts** tab of the permissioning management dapp, hover over the row of
-    the account you are removing. A trash can displays.
-1. Select the trash can.
-
-## Update admins
-
-You can add or remove admins in the same way as [accounts](#update-accounts-allowlist), except on the **Admins** tab.
 
 ## Specify the permissioning contract interface version
 

--- a/docs/private-networks/how-to/use-permissioning/onchain.md
+++ b/docs/private-networks/how-to/use-permissioning/onchain.md
@@ -6,7 +6,6 @@ description: Use onchain permissioning allowlists
 
 This page contains some extra info if you're using [onchain permissioning](../../concepts/permissioning/onchain.md).
 
-
 !!! tip
 
     If your node has two different IP addresses for ingress and egress

--- a/docs/private-networks/tutorials/permissioning/onchain.md
+++ b/docs/private-networks/tutorials/permissioning/onchain.md
@@ -5,17 +5,11 @@ description: Setting up and using Hyperledger Besu onchain permissioning
 # Get started with onchain permissioning
 
 The following steps describe bootstrapping a permissioned network using a Hyperledger Besu
-node and a development server to run the permissioning management dapp.
+node.
 
 This tutorial configures permissioning on a [IBFT 2.0 proof of authority (PoA)] network.
 
-!!! note
-
-    Production environments require a Web server to [host the permissioning management dapp](../../how-to/use-permissioning/onchain.md).
-
 ## Prerequisites
-
-For the development server to run the dapp:
 
 * [Node.js](https://nodejs.org/en/) v10.16.0 or later
 * [Yarn](https://yarnpkg.com/en/) v1.15 or later
@@ -310,11 +304,7 @@ Clone the `permissioning-smart-contracts` repository:
 git clone https://github.com/ConsenSys/permissioning-smart-contracts.git
 ```
 
-Change into the `permissioning-smart-contracts` directory and run:
-
-```bash
-yarn install
-```
+Change into the `permissioning-smart-contracts` directory.
 
 ### 12. Set the environment variables
 
@@ -329,7 +319,8 @@ Create the following environment variables and set to the specified values:
   port (`http://127.0.0.1:8545`). Set to JSON-RPC host and port. When bootstrapping the network,
   Besu uses the specified node to deploy the contracts and is the first node in the network.
 * `CHAIN_ID` - The chain ID from the genesis file.
-* `INITIAL_ALLOWLISTED_NODES`(optional) - The enode URLs of permitted nodes. Specify multiple nodes as a comma-separated list.
+* `INITIAL_ALLOWLISTED_NODES`(optional) - The enode URLs of permitted nodes. Specify multiple nodes
+(Node-1, Node-2, Node-3) as a comma-separated list.
 
 !!! tip
 
@@ -347,15 +338,7 @@ Create the following environment variables and set to the specified values:
 
     If using a `.env` file, save the file to the `permissioning-smart-contracts` directory.
 
-### 13. Build the project
-
-In the `permissioning-smart-contracts` directory, build the project:
-
-```bash
-yarn run build
-```
-
-### 14. Deploy the contracts
+### 13. Deploy the contracts
 
 In the `permissioning-smart-contracts` directory, while your network is running, deploy the Admin and Rules contracts:
 
@@ -369,43 +352,6 @@ The migration logs the addresses of the Admin and Rules contracts.
 !!! important
 
     The account that deploys the contracts is automatically an [admin account].
-
-### 15. Start the permissioning management dapp
-
-!!! note
-
-    Production environments require a Web server to
-    [host the permissioning management dapp](../../how-to/use-permissioning/onchain.md).
-
-1. In the `permissioning-smart-contracts` directory, start the Web server serving the dapp:
-
-    ```bash
-    yarn start
-    ```
-
-    The dapp displays at [`http://localhost:3000`](http://localhost:3000).
-
-1. Ensure MetaMask connects to your local node (by default [`http://localhost:8545`](http://localhost:8545)).
-
-    A MetaMask notification displays requesting permission for Besu Permissioning to connect to your
-    account.
-
-1. Select the **Connect** button.
-
-    The dapp displays with the account specified by the `BESU_NODE_PERM_ACCOUNT` environment
-    variable in the **Accounts** and **Admins** tabs.
-
-!!! note
-
-    Only an [admin account] can add or remove nodes from the allowlist.
-
-### 16. Add nodes to the allowlist
-
-In the [permissioning management dapp started in step 15](#15-start-the-permissioning-management-dapp),
-add [Node-1, Node-2, Node-3, and Node-4 to the allowlist].
-
-Alternatively, You can add the enode URLs in `INITIAL_ALLOWLISTED_NODES`,
-when specifying environment variables in [step 12](#12-set-the-environment-variables).
 
 <!-- Links -->
 [Node-1, Node-2, Node-3, and Node-4 to the allowlist]: ../../how-to/use-permissioning/onchain.md#update-nodes-allowlist

--- a/docs/private-networks/tutorials/permissioning/onchain.md
+++ b/docs/private-networks/tutorials/permissioning/onchain.md
@@ -351,9 +351,8 @@ The migration logs the addresses of the Admin and Rules contracts.
 
 !!! important
 
-    The account that deploys the contracts is automatically an [admin account].
+    The account that deploys the contracts is automatically an admin account.
 
 <!-- Links -->
 [Node-1, Node-2, Node-3, and Node-4 to the allowlist]: ../../how-to/use-permissioning/onchain.md#update-nodes-allowlist
-[admin account]: ../../how-to/use-permissioning/onchain.md#update-nodes-allowlist
 [IBFT 2.0 proof of authority (PoA)]: ../../how-to/configure/consensus/ibft.md

--- a/docs/private-networks/tutorials/permissioning/upgrade-contracts.md
+++ b/docs/private-networks/tutorials/permissioning/upgrade-contracts.md
@@ -9,8 +9,6 @@ version.
 
 ## Prerequisites
 
-For the development server to run the dapp:
-
 <!-- vale off -->
 * [Node.js](https://nodejs.org/en/) v10.16.0 or later
 <!-- vale on -->
@@ -31,20 +29,6 @@ For the development server to run the dapp:
     ```bash
     git clone https://github.com/ConsenSys/permissioning-smart-contracts.git
     ```
-
-1. Change into the `permissioning-smart-contracts` directory and run:
-
-    ```bash
-    yarn install
-    ```
-
-### 2. Build the project
-
-In the `permissioning-smart-contracts` directory, build the project:
-
-```bash
-yarn run build
-```
 
 ### 3. Update environment variables
 
@@ -76,7 +60,6 @@ the file must be in the `permissioning-smart-contracts` directory.
 !!! note
 
     This step enables you to export the current allowlists to assist in updating.
-    You can set these lists via the dapp if you prefer.
 
 1. Export the current allowlists by setting the following environment variables:
 
@@ -144,17 +127,7 @@ the file must be in the `permissioning-smart-contracts` directory.
     truffle migrate --reset
     ```
 
-### 6. Start the permissioning management dapp
-
-In the `permissioning-smart-contracts` directory, start the Web server:
-
-```bash
-yarn start
-```
-
-The dapp displays at [`http://localhost:3000`](http://localhost:3000).
-
-### 7. Restart Besu nodes
+### 6. Restart Besu nodes
 
 Restart the Besu nodes with the updated [`NodeIngress`](#5-deploy-the-contracts)
 contract address and [permissioning contract interface](../../how-to/use-permissioning/onchain.md#specify-the-permissioning-contract-interface-version)


### PR DESCRIPTION
Remove references to the permissioning dapp. Smart contracts can still be used but the dapp doesn't work for new users.

Fixes #1238 

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

## After creating your PR and tests have finished

Make sure that:

- [ ] You've fixed any issues raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation)
  and added a [preview link](#preview).

## Preview

https://hyperledger-besu--1239.org.readthedocs.build/en/1239/private-networks/concepts/permissioning/onchain/
https://hyperledger-besu--1239.org.readthedocs.build/en/1239/private-networks/how-to/use-permissioning/onchain/
https://hyperledger-besu--1239.org.readthedocs.build/en/1239/private-networks/tutorials/permissioning/onchain/
