### PR TITLE
removed unused page reference

### DIFF
--- a/docs/public-networks/reference/genesis-items.md
+++ b/docs/public-networks/reference/genesis-items.md
@@ -163,4 +163,3 @@ Anything listed in the configuration file also takes precedence.
 
 <!--links-->
 [GoQuorum clients]: https://consensys.net/docs/goquorum/en/stable/
-[interoperable private transactions]: ../../private-networks/how-to/use-privacy/goquorum-compatible.md


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Removed a reference that is unused within the page 

- [x] Documentation content
- [ ] Documentation page organization

## Preview

<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
