### PR TITLE
Added uncle block difficulty info to Block Object.

### DIFF
--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -32,7 +32,7 @@ Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash) and
 | `receiptsRoot`     | Data, 32&nbsp;bytes   | Root of the receipts trie for the block.                           |
 | `miner`            | Data, 20&nbsp;bytes   | Address to pay mining rewards to.                                  |
 | `difficulty`       | Quantity, Integer     | Difficulty for this block.                                         |
-| `totalDifficulty`  | Quantity, Integer     | Total difficulty of the chain until this block.                    |
+| `totalDifficulty`  | Quantity, Integer     | Total difficulty of the chain until this block. This value will always be `0` for an uncle block. |
 | `extraData`        | Data                  | Extra data field for this block. The first 32 bytes is vanity data you can set using the [`--miner-extra-data`](../cli/options.md#miner-extra-data) command line option. Stores extra data when used with [Clique](../../../private-networks/how-to/configure/consensus/clique.md#genesis-file) and [IBFT](../../../private-networks/how-to/configure/consensus/ibft.md#genesis-file). |
 | `size`             | Quantity, Integer     | Size of block in bytes.                                            |
 | `gasLimit`         | Quantity              | Maximum gas allowed in this block.                                 |


### PR DESCRIPTION
Signed-off-by: mark-terry <mark.terry@consensys.net>

## Pull request checklist

Use the following list to make sure your PR fits the Besu documentation quality standard.

### Before creating the pull request

Make sure that:

- [x] [All commits in this PR are signed off for the DCO](https://wiki.hyperledger.org/display/BESU/DCO).
- [x] You've read the [contribution guidelines](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] You've [previewed your changes locally](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation).

## Describe the change
Added extra detail to the Total Difficulty field in Block Object, where the value will always be `0` for an uncle block.

## Issue fixed
See [hyperledger/besu/#4238](https://github.com/hyperledger/besu/issues/4238)

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] Github Actions workflow
- [ ] Build and QA tools configuration (for example, lint rules or Vale style)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] Read the Docs configuration
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've fixed any issues raised by the tests.
- [ ] You've [previewed your changes on Read the Docs](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation)
  and added a [preview link](#preview).

## Preview
https://hyperledger-besu--1248.org.readthedocs.build/en/1248/
<!-- Add the link to preview your changes on Read the Docs.

The link format is "https://hyperledger-besu--{your PR number}.org.readthedocs.build/en/{your PR number}/",
where {your PR number} is replaced by the number of this PR.
-->
