### PR TITLE
remove launcher doc

### DIFF
--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -7,8 +7,7 @@ description: Starting Hyperledger Besu
 Nodes can connect to Ethereum Mainnet and public testnets.
 
 Use the [`besu`](../reference/cli/options.md) command with the required command line options
-to start a node. Alternatively, use the [launcher](#besu-launcher) to start Besu interactively
-with the most common options.
+to start a node.
 
 ## Prerequisites
 
@@ -136,41 +135,6 @@ besu --rpc-http-enabled
 ```
 
 See the [guide on connecting to Mainnet](connect/mainnet.md) for more information.
-
-## Besu launcher
-
-Use the Besu launcher to interactively configure and start a node with the most common options. The
-launcher asks a series of questions and generates a [configuration file](../how-to/configuration-file.md).
-
-To run the Besu launcher:
-
-```bash
-besu --Xlauncher
-```
-
-Answer each question, or press ++Enter++ to accept the default value.
-
-```bash
-? Which Ethereum network would you like to use ? goerli
-? Which synchronization mode? fast
-? Do you want to enable pruning? no
-? What is the data directory ? /Users/me/besu
-? Do you want to enable the JSON-RPC HTTP service ? yes
-? Do you want to configure the JSON-RPC options now ? yes
-? What is the JSON RPC HTTP host address ? 127.0.0.1
-? What is the JSON RPC HTTP port ? 8545
-? Select the list of APIs to enable on JSON-RPC HTTP service [eth, net, web3]
-? Do you want to enable the JSON-RPC Websocket service ? no
-? Do you want to enable GraphQL functionality ? no
-? Do you want to use Ethstats ? no
-? Do you want to enable NAT ? no
-? Do you want to enable mining ? no
-```
-
-If a configuration file is already present in the directory where the command is executed,
-Besu will start and use the values in the configuration file. To force the launcher to interact
-during a restart, use the `--Xlauncher-force` option, or delete the configuration
-file.
 
 ## Confirm node is running
 


### PR DESCRIPTION
Remove reference to launcher CLI
See https://github.com/hyperledger/besu/pull/5355

- [x] Documentation content
- [ ] Documentation page organization

Make sure that:

- [x] You've fixed any issues raised by the tests.
- [x] You've [previewed your changes on Read the Docs](https://wiki.hyperledger.org/display/BESU/Preview+the+documentation)
  and added a [preview link](#preview).

## Preview

https://hyperledger-besu--1306.org.readthedocs.build/en/1306/public-networks/get-started/start-node/
