### PR TITLE
Unix timestamp (milliseconds)

### DIFF
--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -37,7 +37,7 @@ Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash) and
 | `size`             | Quantity, Integer     | Size of block in bytes.                                            |
 | `gasLimit`         | Quantity              | Maximum gas allowed in this block.                                 |
 | `gasUsed`          | Quantity              | Total gas used by all transactions in this block.                  |
-| `timestamp`        | Quantity              | Unix timestamp for block assembly.                                 |
+| `timestamp`        | Quantity              | Unix timestamp (milliseconds) for block assembly.                  |
 | `transactions`     | Array                 | Array of [transaction objects](#transaction-object), or 32 byte transaction hashes depending on the specified boolean parameter. |
 | `uncles`           | Array                 | Array of uncle hashes.                                             |
 | `baseFeePerGas`    | Quantity              | The block's [base fee per gas](../../concepts/transactions/types.md#eip1559-transactions). This field is empty for blocks created before [EIP-1559](https://github.com/ethereum/EIPs/blob/2d8a95e14e56de27c5465d93747b0006bd8ac47f/EIPS/eip-1559.md). |

--- a/docs/public-networks/reference/engine-api/objects.md
+++ b/docs/public-networks/reference/engine-api/objects.md
@@ -22,7 +22,7 @@ Returned by [`engine_getPayloadV1`](index.md#engine_getpayloadv1).
 | `blockNumber`   | *Quantity*, 64 Bits   | Block number of block containing this transaction.               |
 | `gasLimit`      | *Quantity*, 64 Bits   | Maximum gas allowed in this block.                               |
 | `gasUsed`       | *Quantity*, 64 Bits   | Total gas used by all transactions in this block.                |
-| `timestamp`     | *Quantity*, 64 Bits   | Unix timestamp for block assembly.                               |
+| `timestamp`     | *Quantity*, 64 Bits   | Unix timestamp (milliseconds) for block assembly.                |
 | `extraData`     | *Data*, 0 to 32 Bytes | Extra data field for this block.                                 |
 | `baseFeePerGas` | *Quantity*, 256 Bits  | The block's [base fee per gas](../../concepts/transactions/types.md#eip1559-transactions). This field is empty for blocks created before [EIP-1559](https://github.com/ethereum/EIPs/blob/2d8a95e14e56de27c5465d93747b0006bd8ac47f/EIPS/eip-1559.md). |
 | `blockHash`     | *Data*, 32 Bytes      | Hash of the execution block.                                     |


### PR DESCRIPTION
Fixes #1321 

- [x] Documentation content
- [ ] Documentation page organization

