### PR TITLE
Added note that min-block-occupancy-ratio is ignored for PoS

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -1569,6 +1569,12 @@ min-block-occupancy-ratio="0.5"
 
 Minimum occupancy ratio for a mined block if the transaction pool is not empty. When filling a block during mining, the occupancy ratio indicates the threshold at which the node stops waiting for smaller transactions to fill the remaining space. The default is 0.8.
 
+:::note
+
+The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+
+:::
+
 ### `miner-coinbase`
 
 <!--tabs-->

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -1571,7 +1571,7 @@ Minimum occupancy ratio for a mined block if the transaction pool is not empty. 
 
 :::note
 
-The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+Besu ignores the `--min-block-occupancy-ratio` option for proof of stake networks (for example, Mainnet).
 
 :::
 

--- a/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
@@ -1569,7 +1569,12 @@ min-block-occupancy-ratio="0.5"
 
 Minimum occupancy ratio for a mined block if the transaction pool is not empty. When filling a block during mining, the occupancy ratio indicates the threshold at which the node stops waiting for smaller transactions to fill the remaining space. The default is 0.8.
 
-**Note**: The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+:::note
+
+The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+
+:::
+
 
 ### `miner-coinbase`
 

--- a/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
@@ -1569,6 +1569,8 @@ min-block-occupancy-ratio="0.5"
 
 Minimum occupancy ratio for a mined block if the transaction pool is not empty. When filling a block during mining, the occupancy ratio indicates the threshold at which the node stops waiting for smaller transactions to fill the remaining space. The default is 0.8.
 
+**Note**: The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+
 ### `miner-coinbase`
 
 <!--tabs-->

--- a/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
@@ -1571,7 +1571,7 @@ Minimum occupancy ratio for a mined block if the transaction pool is not empty. 
 
 :::note
 
-The `--min-block-occupancy-ratio` option is currently ignored for PoS (Proof of Stake) networks in Hyperledger Besu. This means that setting this option will not have any effect when running Besu with a PoS consensus mechanism.
+Besu ignores the `--min-block-occupancy-ratio` option for proof of stake networks (for example, Mainnet).
 
 :::
 


### PR DESCRIPTION
 Added a note in the min-block-occupancy-ratio section that it is ignored for PoS.
 Issue #1344 