### PR TITLE
Remove 'raft' from sample helm values.yml, replace 'ibft' with 'ibft2'

### DIFF
--- a/docs/private-networks/tutorials/kubernetes/charts.md
+++ b/docs/private-networks/tutorials/kubernetes/charts.md
@@ -233,7 +233,7 @@ rawGenesisConfig:
     config:
       chainId: 1337
       algorithm:
-        consensus: qbft # choose from: ibft | qbft | raft | clique
+        consensus: qbft # choose from: ibft2 | qbft | clique
         blockperiodseconds: 10
         epochlength: 30000
         requesttimeoutseconds: 20

--- a/versioned_docs/version-23.4.0/private-networks/tutorials/kubernetes/charts.md
+++ b/versioned_docs/version-23.4.0/private-networks/tutorials/kubernetes/charts.md
@@ -231,7 +231,7 @@ rawGenesisConfig:
     config:
       chainId: 1337
       algorithm:
-        consensus: qbft # choose from: ibft | qbft | raft | clique
+        consensus: qbft # choose from: ibft2 | qbft | clique
         blockperiodseconds: 10
         epochlength: 30000
         requesttimeoutseconds: 20


### PR DESCRIPTION
I noticed that the Besu docs have `raft` in the example helm chart options, which Besu doesn't support. Also `ibft` is deprecated and has been replaced with `ibft2` so thought I'd update that as well.