### PR TITLE
Updated topics to be both public & private

### DIFF
--- a/docs/public-networks/how-to/use-besu-api/access-logs.md
+++ b/docs/public-networks/how-to/use-besu-api/access-logs.md
@@ -3,6 +3,7 @@ title: Access logs using JSON-RPC
 sidebar_position: 5
 description: Accessing logs using the Hyperledger Besu API
 tags:
+  - public networks
   - private networks
 ---
 

--- a/docs/public-networks/how-to/use-besu-api/authenticate.md
+++ b/docs/public-networks/how-to/use-besu-api/authenticate.md
@@ -3,6 +3,7 @@ title: Authenticate over JSON-RPC requests
 sidebar_position: 4
 description: Hyperledger Besu authentication and authorization for JSON-RPC
 tags:
+  - public networks
   - private networks
 ---
 

--- a/docs/public-networks/how-to/use-besu-api/graphql.md
+++ b/docs/public-networks/how-to/use-besu-api/graphql.md
@@ -3,6 +3,7 @@ title: Use GraphQL over HTTP
 sidebar_position: 3
 description: How to access the Hyperledger Besu API using GraphQL
 tags:
+  - public networks
   - private networks
 ---
 

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -3,6 +3,7 @@ title: Use JSON-RPC over HTTP, WS, and IPC
 sidebar_position: 1
 description: How to access the Hyperledger Besu API using JSON-RPC
 tags:
+  - public networks
   - private networks
 ---
 

--- a/docs/public-networks/how-to/use-besu-api/rpc-pubsub.md
+++ b/docs/public-networks/how-to/use-besu-api/rpc-pubsub.md
@@ -3,6 +3,7 @@ title: Use RPC Pub/Sub over WS
 sidebar_position: 2
 description: Using RPC Pub/Sub with Hyperledger Besu WebSockets
 tags:
+  - public networks
   - private networks
 ---
 


### PR DESCRIPTION
Update the Public networks > How to > Use the Besu API topics with both the public networks tag so that now these topics have both the public networks and private networks tags.

Fixes #1371 
