### PR TITLE
Update `lastVersion`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,8 @@ const config = {
           editUrl: "https://github.com/hyperledger/besu-docs/tree/main/",
           path: "./docs",
           includeCurrentVersion: true,
-          lastVersion: "23.7.1",
+          // Set to the last stable release
+          lastVersion: "23.7.2",
           versions: {
             //defaults to the ./docs folder
             // using 'development' instead of 'next' as path
@@ -44,7 +45,7 @@ const config = {
               label: "development",
               path: "development",
             },
-            //the last stable release in the versioned_docs/version-stable
+            // The last stable release in the versioned_docs/version-stable
             "23.7.2": {
               label: "stable (23.7.2)",
             },


### PR DESCRIPTION
PR https://github.com/hyperledger/besu-docs/pull/1397 missed updating the `lastVersion` in the config file. This will update the default version displayed to the latest stable release, fix the stable version URL paths, and update the banners displayed for the development and unmaintained versions accordingly.

preview: https://besu-docs-git-fork-alexandratran-version-fix-hyperledger.vercel.app/public-networks