### PR TITLE
Engine API is enabled by default

### DIFF
--- a/docs/public-networks/how-to/use-engine-api.md
+++ b/docs/public-networks/how-to/use-engine-api.md
@@ -12,30 +12,19 @@ tags:
 
 ## Configure the Engine API
 
-To configure the Engine API:
+The Engine API is enabled by default even if no consensus client configuration exists. You may configure the Engine API, for example, to change the service port number or to specify the host allowlist:
 
-- [Enable the Engine API](#enable-the-engine-api) (it's disabled by default).
-- [Enable the JSON-RPC API](use-besu-api/index.md#enable-api-access). Ensure the [`ETH` method is enabled](use-besu-api/json-rpc.md#api-methods-enabled-by-default) (it's enabled by default).
 - Specify the [service ports](#service-ports).
 - Specify the [host allowlist](#host-allowlist).
 
 ```bash title="Example Engine API configuration"
-besu --engine-rpc-enabled --rpc-http-enabled --engine-rpc-port=8551 --engine-host-allowlist=localhost,127.0.0.1 --engine-jwt-secret=jwt.hex
+besu --engine-rpc-port=8551 --engine-host-allowlist=localhost,127.0.0.1 --engine-jwt-secret=jwt.hex
 ```
 
-### Enable the Engine API
-
-Enable the Engine API with the [`--engine-rpc-enabled`](../reference/cli/options.md#engine-rpc-enabled) CLI option.
-
-:::note
-
-The `--engine-rpc-enabled` CLI option enables the Engine API even if no consensus client configuration exists.
-
-:::
 
 ### Service ports
 
-To specify the port the Engine API service listens on for HTTP and WebSocket, use the [`--engine-rpc-port`](../reference/cli/options.md#engine-rpc-port) option. The default is `8551`.
+To specify the port the Engine API service listens on for HTTP and WebSocket, use the [`--engine-rpc-port`](../reference/cli/options.md#engine-rpc-port) option. The default is `8551`. This is useful when you have another execution engine running that is using the port 8551, in which you can use this flag to specify Besu to use another port, e.g., `--engine-rpc-port 8552`.
 
 ### Host allowlist
 

--- a/docs/public-networks/how-to/use-engine-api.md
+++ b/docs/public-networks/how-to/use-engine-api.md
@@ -12,7 +12,7 @@ tags:
 
 ## Configure the Engine API
 
-The Engine API is enabled by default even if no consensus client configuration exists. You may configure the Engine API, for example, to change the service port number or to specify the host allowlist:
+The Engine API is enabled by default even if no consensus client configuration exists. You can configure the Engine API to:
 
 - Specify the [service ports](#service-ports).
 - Specify the [host allowlist](#host-allowlist).
@@ -24,7 +24,7 @@ besu --engine-rpc-port=8551 --engine-host-allowlist=localhost,127.0.0.1 --engine
 
 ### Service ports
 
-To specify the port the Engine API service listens on for HTTP and WebSocket, use the [`--engine-rpc-port`](../reference/cli/options.md#engine-rpc-port) option. The default is `8551`. This is useful when you have another execution engine running that is using the port 8551, in which you can use this flag to specify Besu to use another port, e.g., `--engine-rpc-port 8552`.
+To specify the port the Engine API service listens on for HTTP and WebSocket, use the [`--engine-rpc-port`](../reference/cli/options.md#engine-rpc-port) option. The default is `8551`. This option is useful when you have another execution engine running on port 8551, in which case you can specify Besu to use another port, for example, `--engine-rpc-port 8552`.
 
 ### Host allowlist
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -657,7 +657,7 @@ engine-rpc-enabled=true
 
 <!--/tabs-->
 
-Enables or disables the [Engine API](../engine-api/index.md). The default is `false`.
+Enables or disables the [Engine API](../engine-api/index.md). The default is `true`.
 
 ### `engine-rpc-port`
 

--- a/docs/public-networks/reference/engine-api/index.md
+++ b/docs/public-networks/reference/engine-api/index.md
@@ -11,7 +11,7 @@ tags:
 
 :::info
 
-Ensure you enable the Engine API methods with the [`--engine-rpc-enabled`](../cli/options.md#engine-rpc-enabled) CLI option.
+The engine API is enabled by default.
 
 :::
 


### PR DESCRIPTION
The Engine API is enabled by default (without needing the flag `--engine-rpc-enabled`). This PR removes the line that states it is disabled by default and some that are not required.