### PR TITLE
Updated environment variable example for bonsai-historical-block-limit

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -278,7 +278,7 @@ The singular `--banned-node-id` and plural `--banned-node-ids` are available and
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---bonsai-historical-block-limit=256
+--bonsai-historical-block-limit=<INTEGER>
 ```
 
 </TabItem>
@@ -294,7 +294,7 @@ The singular `--banned-node-id` and plural `--banned-node-ids` are available and
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_BONSAI_MAXIMUM_BACK_LAYERS_TO_LOAD=256
+BESU_BONSAI_HISTORICAL_BLOCK_LIMIT=256
 ```
 
 </TabItem>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,8 +11,7 @@ function HomepageText() {
         <a href="/public-networks/reference/cli/options">
           command line interface
         </a>{" "}
-        and{" "}
-        <a href="/public-networks/how-to/use-besu-api">JSON-RPC API</a> for
+        and <a href="/public-networks/how-to/use-besu-api">JSON-RPC API</a> for
         running, maintaining, debugging, and monitoring nodes in an Ethereum
         network. You can use the API via RPC over HTTP or via WebSocket. Besu
         also supports Pub/Sub.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ function HomepageText() {
         <a href="/public-networks/reference/cli/options">
           command line interface
         </a>{" "}
-        and
+        and{" "}
         <a href="/public-networks/how-to/use-besu-api">JSON-RPC API</a> for
         running, maintaining, debugging, and monitoring nodes in an Ethereum
         network. You can use the API via RPC over HTTP or via WebSocket. Besu


### PR DESCRIPTION
environment variable still had the old name

also added a missing space on landing page