### PR TITLE
Add Joan as docs maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,8 +9,8 @@
 |------------------|--------------------|--------------------|
 | Alexandra Tran   | alexandratran      | alexandratran      |
 | Byron Gravenorst | bgravenorst        | bgravenorst        |
-| Madeline Murray  | MadelineMurray     | madelinemurray     |
 | Joan Edwards     | joaniefromtheblock | joaniefromtheblock |
+| Madeline Murray  | MadelineMurray     | madelinemurray     |
 <!-- vale on -->
 
 ## Emeritus maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,12 +5,12 @@
 <!-- Please keep this sorted alphabetically by github -->
 
 <!-- vale off -->
-| Name             | GitHub         | LFID           |
-|------------------|----------------|----------------|
-| Alexandra Tran   | alexandratran  | alexandratran  |
-| Byron Gravenorst | bgravenorst    | bgravenorst    |
-| Madeline Murray  | MadelineMurray | madelinemurray |
-| Mike Sanko       | mjsmike62      | mjsmike62      |
+| Name             | GitHub             | LFID               |
+|------------------|--------------------|--------------------|
+| Alexandra Tran   | alexandratran      | alexandratran      |
+| Byron Gravenorst | bgravenorst        | bgravenorst        |
+| Madeline Murray  | MadelineMurray     | madelinemurray     |
+| Joan Edwards     | joaniefromtheblock | joaniefromtheblock |
 <!-- vale on -->
 
 ## Emeritus maintainers
@@ -23,6 +23,7 @@
 | Tim Beiko       | timbeiko       | timbeiko       |
 | Nicolas Massart | NicolasMassart | NicolasMassart |
 | Roland Tyler    | rolandtyler    | rolandtyler    |
+| Mike Sanko      | mjsmike62      | mjsmike62      |
 <!-- vale on -->
 
 ## Becoming a maintainer


### PR DESCRIPTION
This PR adds Joan Edwards (@joaniefromtheblock) to the list of Besu docs maintainers. She has authored the following PRs:

- #1485 
- #1486 
- #1490 
- #1501 
- #1504 
- #1502 
- #1503 

You can see [her current list of PRs](https://github.com/hyperledger/besu-docs/pulls?q=is%3Apr+author%3Ajoaniefromtheblock+).

> Note: This PR also moves Mike Sanko to emeritus status.