### PR TITLE
Add sequenced synonym for legacy txpool

### DIFF
--- a/docs/public-networks/concepts/transactions/pool.md
+++ b/docs/public-networks/concepts/transactions/pool.md
@@ -60,8 +60,7 @@ If you previously configured transaction pool behavior, upgrade to the layered t
   To configure the maximum memory capacity, use [`--tx-pool-layer-max-capacity`](../../reference/cli/options.md#tx-pool-layer-max-capacity).
 
 You can opt out of the layered transaction pool implementation by setting the
-[`--tx-pool`](../../reference/cli/options.md#tx-pool) option to `legacy`, but the legacy
-implementation will be deprecated soon, so we recommend using the layered pool.
+[`--tx-pool`](../../reference/cli/options.md#tx-pool) option to `sequenced`.
 
 ## Dropping transactions when the transaction pool is full
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -4706,7 +4706,7 @@ Use the [`miner_changeTargetGasLimit`](../api/index.md#miner_changetargetgaslimi
 <TabItem value="Example" label="Example">
 
 ```bash
---tx-pool=legacy
+--tx-pool=sequenced
 ```
 
 </TabItem>
@@ -4714,7 +4714,7 @@ Use the [`miner_changeTargetGasLimit`](../api/index.md#miner_changetargetgaslimi
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_TX_POOL=legacy
+BESU_TX_POOL=sequenced
 ```
 
 </TabItem>
@@ -4722,7 +4722,7 @@ BESU_TX_POOL=legacy
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-tx-pool="legacy"
+tx-pool="sequenced"
 ```
 
 </TabItem>
@@ -4731,7 +4731,7 @@ tx-pool="legacy"
 
 Type of [transaction pool](../../concepts/transactions/pool.md) to use.
 Set to `layered` to use the layered transaction pool implementation.
-Set to `sequenced` or `legacy` to opt out of the layered transaction pool.
+Set to `sequenced` (previously known as `legacy`) to opt out of the layered transaction pool.
 The default is `layered`.
 
 ### `tx-pool-enable-save-restore`

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -4731,13 +4731,8 @@ tx-pool="legacy"
 
 Type of [transaction pool](../../concepts/transactions/pool.md) to use.
 Set to `layered` to use the layered transaction pool implementation.
-Set to `legacy` to opt out of the layered transaction pool.
+Set to `sequenced` or `legacy` to opt out of the layered transaction pool.
 The default is `layered`.
-
-:::caution
-The legacy transaction pool implementation will be deprecated soon, so we recommend using the
-default layered transaction pool.
-:::
 
 ### `tx-pool-enable-save-restore`
 


### PR DESCRIPTION
Add `sequenced` synonym for `legacy` non-layered transaction pool, and remove deprecation warnings for non-layered transaction pool. Fixes #1470.

Preview: https://besu-docs-mg2txtj7o-hyperledger.vercel.app/development/public-networks/reference/cli/options#tx-pool