### PR TITLE
SNAP and Bonsai are now Besu defaults

### DIFF
--- a/docs/public-networks/get-started/connect/mainnet.md
+++ b/docs/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \
@@ -109,7 +109,7 @@ After starting Besu and the consensus client, your node starts syncing and conne
 
 ```bash
 {"@timestamp":"2023-02-03T04:43:49,555","level":"INFO","thread":"main","class":"DefaultSynchronizer","message":"Starting synchronizer.","throwable":""}
-{"@timestamp":"2023-02-03T04:43:49,556","level":"INFO","thread":"main","class":"FastSyncDownloader","message":"Starting sync","throwable":""}
+{"@timestamp":"2023-02-03T04:43:49,556","level":"INFO","thread":"main","class":"SnapSyncDownloader","message":"Starting sync","throwable":""}
 {"@timestamp":"2023-02-03T04:43:49,559","level":"INFO","thread":"main","class":"Runner","message":"Ethereum main loop is up.","throwable":""}
 {"@timestamp":"2023-02-03T04:43:53,106","level":"INFO","thread":"Timer-0","class":"DNSResolver","message":"Resolved 2409 nodes","throwable":""}
 {"@timestamp":"2023-02-03T04:45:04,803","level":"INFO","thread":"nioEventLoopGroup-3-10","class":"SnapWorldStateDownloader","message":"Downloading world state from peers for pivot block 16545859 (0x616ae3c4cf85f95a9bce2814a7282d75dc2eac36
@@ -119,7 +119,7 @@ cb9f0fcc6f16386df70da3c5). State root 0xa7114541f42c62a72c8b6bb9901c2ccf4b424cd7
 {"@timestamp":"2023-02-03T04:49:09,931","level":"INFO","thread":"EthScheduler-Services-3 (batchPersistAccountData)","class":"SnapsyncMetricsManager","message":"Worldstate download progress: 0.41%, Peer count: 11","throwable":""}
 {"@timestamp":"2023-02-03T04:50:12,466","level":"INFO","thread":"EthScheduler-Services-3 (batchPersistAccountData)","class":"SnapsyncMetricsManager","message":"Worldstate download progress: 0.61%, Peer count: 10","throwable":""}
 {"@timestamp":"2023-02-03T04:51:20,977","level":"INFO","thread":"EthScheduler-Services-3 (batchPersistAccountData)","class":"SnapsyncMetricsManager","message":"Worldstate download progress: 0.75%, Peer count: 10","throwable":""}
-{"@timestamp":"2023-02-03T04:51:28,985","level":"INFO","thread":"EthScheduler-Services-29 (importBlock)","class":"FastImportBlocksStep","message":"Block import progress: 180400 of 16545859 (1%)","throwable":""}
+{"@timestamp":"2023-02-03T04:51:28,985","level":"INFO","thread":"EthScheduler-Services-29 (importBlock)","class":"ImportBlocksStep","message":"Block import progress: 180400 of 16545859 (1%)","throwable":""}
 ```
 
 </TabItem>

--- a/docs/public-networks/get-started/connect/mainnet.md
+++ b/docs/public-networks/get-started/connect/mainnet.md
@@ -58,8 +58,6 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=SNAP           \
-  --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \
   --rpc-ws-enabled=true        \

--- a/docs/public-networks/get-started/connect/mainnet.md
+++ b/docs/public-networks/get-started/connect/mainnet.md
@@ -75,8 +75,6 @@ Specify:
 
 Also, in the command:
 
-- [`--sync-mode`](../../reference/cli/options.md#sync-mode) specifies using [snap sync](sync-node.md#snap-synchronization).
-- [`--data-storage-format`](../../reference/cli/options.md#data-storage-format) specifies using [Bonsai Tries](../../concepts/data-storage-formats.md#bonsai-tries).
 - [`--rpc-http-enabled`](../../reference/cli/options.md#rpc-http-enabled) enables the HTTP JSON-RPC service.
 - [`--rpc-http-host`](../../reference/cli/options.md#rpc-http-host) is set to `0.0.0.0` to allow remote RPC connections.
 - [`--rpc-ws-enabled`](../../reference/cli/options.md#rpc-ws-enabled) enables the WebSocket JSON-RPC service.

--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -57,11 +57,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -69,13 +69,7 @@ See [how to read the Besu metrics charts](../../how-to/monitor/understand-metric
 
 ### Checkpoint synchronization
 
-:::caution
-
-Checkpoint sync is an early access feature.
-
-:::
-
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -533,7 +533,7 @@ The path to the Besu data directory. The default is the directory you installed 
 <TabItem value="Example" label="Example">
 
 ```bash
---data-storage-format=BONSAI
+--data-storage-format=FOREST
 ```
 
 </TabItem>
@@ -541,7 +541,7 @@ The path to the Besu data directory. The default is the directory you installed 
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_DATA_STORAGE_FORMAT=BONSAI
+BESU_DATA_STORAGE_FORMAT=FOREST
 ```
 
 </TabItem>
@@ -556,7 +556,7 @@ data-storage-format="BONSAI"
 
 </Tabs>
 
-The [data storage format](../../concepts/data-storage-formats.md) to use. Set to `BONSAI` for Bonsai Tries or `FOREST` for Forest of Tries. The default is `FOREST`.
+The [data storage format](../../concepts/data-storage-formats.md) to use. Set to `BONSAI` for Bonsai Tries or `FOREST` for Forest of Tries. The default is `BONSAI`.
 
 ### `discovery-dns-url`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -4691,7 +4691,7 @@ This option does not apply to Proof of Stake networks.
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4699,7 +4699,7 @@ This option does not apply to Proof of Stake networks.
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4707,23 +4707,22 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
-- The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).
+- The default is `SNAP` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `SNAP` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).
 
 :::tip
 
 - We recommend using snap sync over fast sync because snap sync can be faster by several days.
-- Checkpoint sync is an early access feature.
-- It might become impossible to sync Ethereum Mainnet using fast sync in the future. Update Besu to a version that supports newer sync methods.
+- It might become impossible to sync Ethereum Mainnet using fast sync in the future, as clients drop support for fast sync. We recommend you update Besu to a version that supports newer sync methods.
 - When synchronizing in a mode other than `FULL`, most historical world state data is unavailable. Any methods attempting to access unavailable world state data return `null`.
 
 :::

--- a/docs/public-networks/tutorials/besu-teku-mainnet.md
+++ b/docs/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \


### PR DESCRIPTION
A few changes to Besu defaults coming in 24.2.0 -

SNAP and Checkpoint no longer "early access" - so removed references to X_SNAP and X_CHECKPOINT
https://github.com/hyperledger/besu/pull/6405
Snap sync is now default for named networks
https://github.com/hyperledger/besu/pull/6530
Bonsai is now default storage format
https://github.com/hyperledger/besu/pull/6536