### PR TITLE
Update block parameter `pending` and `blockHash`

### DIFF
--- a/docs/private-networks/reference/api/index.md
+++ b/docs/private-networks/reference/api/index.md
@@ -1135,7 +1135,13 @@ For private contracts, `priv_call` is the same as [`eth_call`](../../../public-n
 
 - `call`: _object_ - [transaction call object](../../../public-networks/reference/api/objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -1273,7 +1279,13 @@ Returns the state root of the specified privacy group at the specified block.
 
 - `privacyGroupId`: _string_ - 32-byte [privacy Group ID](../../concepts/privacy/privacy-groups.md)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -1474,7 +1486,13 @@ Returns the code of the private smart contract at the specified address. Compile
 
 - `address`: _string_ - 20-byte contract address
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 

--- a/docs/private-networks/reference/api/index.md
+++ b/docs/private-networks/reference/api/index.md
@@ -76,7 +76,7 @@ Lists [signers for the specified block].
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -124,9 +124,9 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 If you specify:
 
@@ -518,9 +518,9 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 If you specify:
 
@@ -640,7 +640,7 @@ Lists the validators defined in the specified block.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1106,7 +1106,7 @@ For private contracts, `priv_call` is the same as [`eth_call`](../../../public-n
 
 - `call`: _object_ - [transaction call object](../../../public-networks/reference/api/objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1244,7 +1244,7 @@ Returns the state root of the specified privacy group at the specified block.
 
 - `privacyGroupId`: _string_ - 32-byte [privacy Group ID](../../concepts/privacy/privacy-groups.md)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1445,7 +1445,7 @@ Returns the code of the private smart contract at the specified address. Compile
 
 - `address`: _string_ - 20-byte contract address
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -2195,9 +2195,9 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 If you specify:
 

--- a/docs/private-networks/reference/api/index.md
+++ b/docs/private-networks/reference/api/index.md
@@ -1,5 +1,6 @@
 ---
 description: Hyperledger Besu private network JSON-RPC API methods reference
+toc_max_heading_level: 3
 tags:
   - private networks
 ---
@@ -76,7 +77,13 @@ Lists [signers for the specified block].
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -124,9 +131,17 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one
+  of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 If you specify:
 
@@ -518,9 +533,17 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one
+  of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 If you specify:
 
@@ -640,7 +663,13 @@ Lists the validators defined in the specified block.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1106,7 +1135,7 @@ For private contracts, `priv_call` is the same as [`eth_call`](../../../public-n
 
 - `call`: _object_ - [transaction call object](../../../public-networks/reference/api/objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1244,7 +1273,7 @@ Returns the state root of the specified privacy group at the specified block.
 
 - `privacyGroupId`: _string_ - 32-byte [privacy Group ID](../../concepts/privacy/privacy-groups.md)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1445,7 +1474,7 @@ Returns the code of the private smart contract at the specified address. Compile
 
 - `address`: _string_ - 20-byte contract address
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -2195,9 +2224,17 @@ Provides the following validator metrics for the specified range:
 
 #### Parameters
 
-- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one
+  of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 If you specify:
 
@@ -2314,10 +2351,11 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"qbft_getValidatorsByBlockHash","
 ### `qbft_getValidatorsByBlockNumber`
 
 Lists the validators defined in the specified block.
+Use the `pending` tag to get a list of validators that will be used to produce the next block.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../../public-networks/how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -332,9 +332,10 @@ The block parameter can have one of the following values:
 
 - `earliest` : _tag_ - The earliest (genesis) block.
 - `latest` : _tag_ - The last block mined.
-- `pending` : _tag_ - The last block mined plus pending transactions.
-  Use only with [`eth_getTransactionCount`](../../reference/api/index.md#eth_gettransactioncount)
-  and [`qbft_getValidatorsByBlockNumber`](../../../private-networks/reference/api/index.md#qbft_getvalidatorsbyblocknumber).
+- `pending` : _tag_ - When used with [`eth_getTransactionCount`](../../reference/api/index.md#eth_gettransactioncount),
+  refers to the last block mined plus pending transactions.
+  When used with [`qbft_getValidatorsByBlockNumber`](../../../private-networks/reference/api/index.md#qbft_getvalidatorsbyblocknumber),
+  returns a list of validators that will be used to produce the next block.
 - `finalized` : _tag_ - The most recent crypto-economically secure block.
   It cannot be reorganized outside manual intervention driven by community coordination.
 - `safe` : _tag_ - The most recent block that is safe from reorganization under honest majority and

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -303,12 +303,19 @@ To enable the `ADMIN`, `CLIQUE`, `DEBUG`, `EEA`, `IBFT`, `MINER`, `PERM`, `PLUGI
 
 ## Block parameter
 
-When you make requests that might have different results depending on the block accessed, the block parameter specifies the block. Methods such as [`eth_getTransactionByBlockNumberAndIndex`](../../reference/api/index.md#eth_gettransactionbyblocknumberandindex) have a block parameter.
+When you make requests that might have different results depending on the block accessed, the block
+parameter specifies the block.
+Methods such as [`eth_getTransactionByBlockNumberAndIndex`](../../reference/api/index.md#eth_gettransactionbyblocknumberandindex)
+have a block parameter.
 
 The block parameter can have one of the following values:
 
-- `blockNumber` : _quantity_ - The block number, specified in hexadecimal or decimal. 0 represents the genesis block.
-- `blockHash` : _string_ or _object_ - 32-byte block hash or JSON object specifying the block hash. If using a JSON object, you can specify `requireCanonical` to indicate whether the block must be a canonical block. See [this example](https://github.com/hyperledger/besu/blob/a2dedb0b2c7980cdc35db8eb4c094f2eb0dc7deb/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_blockHashObjectCanonical.json).
+- `blockNumber` : _quantity_ - The block number, specified in hexadecimal or decimal.
+  `0` represents the genesis block.
+- `blockHash` : _string_ or _object_ - 32-byte block hash or JSON object specifying the block hash.
+  If using a JSON object, you can specify `requireCanonical` to indicate whether the block must be a
+  canonical block.
+  See [this example](https://github.com/hyperledger/besu/blob/a2dedb0b2c7980cdc35db8eb4c094f2eb0dc7deb/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_blockHashObjectCanonical.json).
 
   :::note
 
@@ -325,6 +332,10 @@ The block parameter can have one of the following values:
 
 - `earliest` : _tag_ - The earliest (genesis) block.
 - `latest` : _tag_ - The last block mined.
-- `pending` : _tag_ - The last block mined plus pending transactions. Use only with [`eth_getTransactionCount`](../../reference/api/index.md#eth_gettransactioncount).
-- `finalized` : _tag_ - The most recent crypto-economically secure block. It cannot be reorganized outside manual intervention driven by community coordination.
-- `safe` : _tag_ - The most recent block that is safe from reorganization under honest majority and certain synchronicity assumptions.
+- `pending` : _tag_ - The last block mined plus pending transactions.
+  Use only with [`eth_getTransactionCount`](../../reference/api/index.md#eth_gettransactioncount)
+  and [`qbft_getValidatorsByBlockNumber`](../../../private-networks/reference/api/index.md#qbft_getvalidatorsbyblocknumber).
+- `finalized` : _tag_ - The most recent crypto-economically secure block.
+  It cannot be reorganized outside manual intervention driven by community coordination.
+- `safe` : _tag_ - The most recent block that is safe from reorganization under honest majority and
+  certain synchronicity assumptions.

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -264,9 +264,17 @@ Removes cache files for the specified range of blocks.
 
 #### Parameters
 
-- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 You can skip a parameter by using an empty string, `""`. If you specify:
 
@@ -994,7 +1002,13 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1038,7 +1052,13 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1088,8 +1108,13 @@ of the transaction receipts of the specified block.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`,
-`earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1326,7 +1351,13 @@ Re-imports the block matching the specified block number, by rolling the head of
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1414,7 +1445,13 @@ Sets the current head of the local chain to the block matching the specified blo
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -1462,11 +1499,11 @@ Use [`debug_standardTraceBadBlockToFile`](#debug_standardtracebadblocktofile) to
 
 #### Parameters
 
-`blockHash`: _string_ - block hash
+- `blockHash`: _string_ - block hash
 
-`txHash`: _string_ - (optional) transaction hash; if omitted, a trace file is generated for each transaction in the block.
+- `txHash`: _string_ - (optional) transaction hash; if omitted, a trace file is generated for each transaction in the block.
 
-`disableMemory`: _boolean_ - (optional) specifies whether to capture EVM memory during the trace; defaults to `true`
+- `disableMemory`: _boolean_ - (optional) specifies whether to capture EVM memory during the trace; defaults to `true`
 
 #### Returns
 
@@ -1883,7 +1920,13 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
 
@@ -1960,7 +2003,13 @@ Performs an [`eth_call`](#eth_call) within the execution environment of a given 
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the
+  string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
 
@@ -2231,20 +2280,26 @@ By default, the `eth_call` error response includes the [revert reason](../../../
 
 #### Parameters
 
-`call`: _object_ - [transaction call object](objects.md#transaction-call-object)
+- `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  :::note
 
-:::note
+  The [`strict` parameter](objects.md#transaction-call-object) determines if the sender account balance is checked:
+  * If `strict:true`, the balance is checked and `eth_call` fails if the sender account has an insufficient balance to send the transaction with the specified gas parameters.
+  * If `strict:false`, the balance is not checked and `eth_call` can succeed even if the sender account has an insufficient balance.
+  * If `strict` is not specified, the balance is checked against the gas parameters if supplied.
 
-The [`strict` parameter](objects.md#transaction-call-object) determines if the sender account balance is checked: 
-* If `strict:true`, the balance is checked and `eth_call` fails if the sender account has an insufficient balance to send the transaction with the specified gas parameters.
-* If `strict:false`, the balance is not checked and `eth_call` can succeed even if the sender account has an insufficient balance. 
-* If `strict` is not specified, the balance is checked against the gas parameters if supplied. 
+  If you do not want the sender account balance checked, send zero gas or specify `strict:false`.
 
-If you do not want the sender account balance checked, send zero gas or specify `strict:false`.
+  :::
 
-:::
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number,
+  block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as
+  described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -2462,9 +2517,15 @@ Creates an [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access list that 
 
 #### Parameters
 
-`transaction`: _object_ - [transaction call object](objects.md#transaction-call-object)
+- `transaction`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -2669,7 +2730,13 @@ As of [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), this method tracks tr
 
 - `blockCount`: _integer_ or _string_ - Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. If blocks in the specified block range are not available, then only the fee history for available blocks is returned. Accepts hexadecimal or integer values.
 
-- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of the requested range, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of
+  the requested range, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `array` of `integers` - (optional) A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
 
@@ -2854,7 +2921,13 @@ Returns the account balance of the specified address.
 
 - `address`: _string_ - 20-byte account address from which to retrieve the balance
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block
+  number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -3087,7 +3160,13 @@ Returns information about the block matching the specified block number.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `verbose`: _boolean_ - if `true`, returns the full [transaction objects](objects.md#transaction-object); if `false`, returns only the hashes of the transactions.
 
@@ -3256,7 +3335,13 @@ gas used and any event logs that might have been produced by a smart contract du
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -3531,7 +3616,13 @@ Returns the number of transactions in a block matching the specified block numbe
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -3614,9 +3705,15 @@ Returns the code of the smart contract at the specified address. Besu stores com
 
 #### Parameters
 
-`address`: _string_ - 20-byte contract address
+- `address`: _string_ - 20-byte contract address
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number,
+  block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as
+  described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -4116,7 +4213,13 @@ Returns miner data for the specified block.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -4182,11 +4285,17 @@ The API allows IoT devices or mobile apps which are unable to run light clients 
 
 #### Parameters
 
-`address`: _string_ - 20-byte address of the account or contract
+- `address`: _string_ - 20-byte address of the account or contract
 
-`keys`: _array_ of _strings_ - list of 32-byte storage keys to generate proofs for
+- `keys`: _array_ of _strings_ - list of 32-byte storage keys to generate proofs for
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block
+  number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -4281,11 +4390,17 @@ Returns the value of a storage position at a specified address.
 
 #### Parameters
 
-`address`: _string_ - 20-byte storage address
+- `address`: _string_ - 20-byte storage address
 
-`index`: _string_ - integer index of the storage position
+- `index`: _string_ - integer index of the storage position
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block
+  number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -4370,9 +4485,9 @@ Returns transaction information for the specified block hash and transaction ind
 
 #### Parameters
 
-`block`: _string_ - 32-byte hash of a block
+- `block`: _string_ - 32-byte hash of a block
 
-`index`: _string_ - integer representing the transaction index position
+- `index`: _string_ - integer representing the transaction index position
 
 #### Returns
 
@@ -4484,9 +4599,15 @@ Returns transaction information for the specified block number and transaction i
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
-`index`: _string_ - transaction index position
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
+
+- `index`: _string_ - transaction index position
 
 #### Returns
 
@@ -4726,9 +4847,9 @@ Returns the number of transactions sent from a specified address. Use the `pendi
 
 #### Parameters
 
-`address`: _string_ - 20-byte account address
+- `address`: _string_ - 20-byte account address
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4949,9 +5070,9 @@ Returns uncle specified by block hash and index.
 
 #### Parameters
 
-`block`: _string_ - 32-byte block hash
+- `block`: _string_ - 32-byte block hash
 
-`uncleIndex`: _string_ - index of the uncle
+- `uncleIndex`: _string_ - index of the uncle
 
 #### Returns
 
@@ -5091,7 +5212,13 @@ Returns uncle specified by block number and index.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `uncleIndex`: _string_ - index of the uncle
 
@@ -5302,7 +5429,13 @@ Returns the number of uncles in a block matching the specified block number.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -6766,7 +6899,13 @@ Your node must be an archive node (that is, synchronized without pruning or fast
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+[block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+:::note
+`pending` returns the same value as `latest`.
+:::
 
 #### Returns
 
@@ -6870,7 +7009,13 @@ The requested transaction must be contained in a block within the number of [blo
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
@@ -6962,7 +7107,13 @@ The requested block must be within the number of [blocks retained](../cli/option
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 #### Returns
 
@@ -7319,7 +7470,13 @@ When using [Forest](../../concepts/data-storage-formats.md#forest-of-tries), the
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of
+  the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in
+  [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+
+  :::note
+  `pending` returns the same value as `latest`.
+  :::
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -2,6 +2,7 @@
 title: Besu API
 sidebar_position: 2
 description: Hyperledger Besu JSON-RPC API methods reference
+toc_max_heading_level: 3
 tags:
   - public networks
   - private networks
@@ -263,9 +264,9 @@ Removes cache files for the specified range of blocks.
 
 #### Parameters
 
-- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 You can skip a parameter by using an empty string, `""`. If you specify:
 
@@ -993,7 +994,7 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1037,7 +1038,7 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1087,7 +1088,7 @@ of the transaction receipts of the specified block.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`,
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`,
 `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
@@ -1325,7 +1326,7 @@ Re-imports the block matching the specified block number, by rolling the head of
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1413,7 +1414,7 @@ Sets the current head of the local chain to the block matching the specified blo
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1882,7 +1883,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
 
@@ -1958,6 +1959,7 @@ Performs an [`eth_call`](#eth_call) within the execution environment of a given 
 #### Parameters
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
+
 - `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
@@ -2667,7 +2669,7 @@ As of [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), this method tracks tr
 
 - `blockCount`: _integer_ or _string_ - Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. If blocks in the specified block range are not available, then only the fee history for available blocks is returned. Accepts hexadecimal or integer values.
 
-- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of the requested range or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of the requested range, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
 
 - `array` of `integers` - (optional) A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
 
@@ -3085,7 +3087,7 @@ Returns information about the block matching the specified block number.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `verbose`: _boolean_ - if `true`, returns the full [transaction objects](objects.md#transaction-object); if `false`, returns only the hashes of the transactions.
 
@@ -3529,7 +3531,7 @@ Returns the number of transactions in a block matching the specified block numbe
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4114,7 +4116,7 @@ Returns miner data for the specified block.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4482,7 +4484,7 @@ Returns transaction information for the specified block number and transaction i
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 `index`: _string_ - transaction index position
 
@@ -5089,7 +5091,7 @@ Returns uncle specified by block number and index.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `uncleIndex`: _string_ - index of the uncle
 
@@ -5300,7 +5302,7 @@ Returns the number of uncles in a block matching the specified block number.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -6764,7 +6766,7 @@ Your node must be an archive node (that is, synchronized without pruning or fast
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -6868,7 +6870,7 @@ The requested transaction must be contained in a block within the number of [blo
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
@@ -6960,7 +6962,7 @@ The requested block must be within the number of [blocks retained](../cli/option
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -7317,7 +7319,7 @@ When using [Forest](../../concepts/data-storage-formats.md#forest-of-tries), the
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -263,9 +263,9 @@ Removes cache files for the specified range of blocks.
 
 #### Parameters
 
-- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `fromBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
-- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `toBlock`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 You can skip a parameter by using an empty string, `""`. If you specify:
 
@@ -993,7 +993,7 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1037,7 +1037,7 @@ Returns the [RLP encoding](https://ethereum.org/en/developers/docs/data-structur
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1088,7 +1088,7 @@ of the transaction receipts of the specified block.
 #### Parameters
 
 `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`,
-`earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1325,7 +1325,7 @@ Re-imports the block matching the specified block number, by rolling the head of
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1413,7 +1413,7 @@ Sets the current head of the local chain to the block matching the specified blo
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -1882,7 +1882,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
 
@@ -1958,7 +1958,7 @@ Performs an [`eth_call`](#eth_call) within the execution environment of a given 
 #### Parameters
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
-- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _object_ - request options object with the following fields (all optional and default to `false`):
 
@@ -2231,7 +2231,7 @@ By default, the `eth_call` error response includes the [revert reason](../../../
 
 `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 :::note
 
@@ -2462,7 +2462,7 @@ Creates an [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access list that 
 
 `transaction`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
 
 #### Returns
 
@@ -2667,7 +2667,7 @@ As of [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), this method tracks tr
 
 - `blockCount`: _integer_ or _string_ - Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. If blocks in the specified block range are not available, then only the fee history for available blocks is returned. Accepts hexadecimal or integer values.
 
-- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of the requested range or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+- `newestBlock`: _string_ - hexadecimal or decimal integer representing the highest number block of the requested range or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
 
 - `array` of `integers` - (optional) A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
 
@@ -2852,7 +2852,7 @@ Returns the account balance of the specified address.
 
 - `address`: _string_ - 20-byte account address from which to retrieve the balance
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -3085,7 +3085,7 @@ Returns information about the block matching the specified block number.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `verbose`: _boolean_ - if `true`, returns the full [transaction objects](objects.md#transaction-object); if `false`, returns only the hashes of the transactions.
 
@@ -3254,7 +3254,7 @@ gas used and any event logs that might have been produced by a smart contract du
 
 #### Parameters
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -3529,7 +3529,7 @@ Returns the number of transactions in a block matching the specified block numbe
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -3614,7 +3614,7 @@ Returns the code of the smart contract at the specified address. Besu stores com
 
 `address`: _string_ - 20-byte contract address
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4114,7 +4114,7 @@ Returns miner data for the specified block.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4184,7 +4184,7 @@ The API allows IoT devices or mobile apps which are unable to run light clients 
 
 `keys`: _array_ of _strings_ - list of 32-byte storage keys to generate proofs for
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4283,7 +4283,7 @@ Returns the value of a storage position at a specified address.
 
 `index`: _string_ - integer index of the storage position
 
-`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber` or `blockHash`: _string_ - hexadecimal or decimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -4482,7 +4482,7 @@ Returns transaction information for the specified block number and transaction i
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 `index`: _string_ - transaction index position
 
@@ -5089,7 +5089,7 @@ Returns uncle specified by block number and index.
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `uncleIndex`: _string_ - index of the uncle
 
@@ -5300,7 +5300,7 @@ Returns the number of uncles in a block matching the specified block number.
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -6764,7 +6764,7 @@ Your node must be an archive node (that is, synchronized without pruning or fast
 
 #### Parameters
 
-`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+`blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -6868,7 +6868,7 @@ The requested transaction must be contained in a block within the number of [blo
 
 - `call`: _object_ - [transaction call object](objects.md#transaction-call-object)
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
@@ -6960,7 +6960,7 @@ The requested block must be within the number of [blocks retained](../cli/option
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 #### Returns
 
@@ -7317,7 +7317,7 @@ When using [Forest](../../concepts/data-storage-formats.md#forest-of-tries), the
 
 #### Parameters
 
-- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber`: _string_ - hexadecimal or decimal integer representing a block number or one of the string tags `latest`, `earliest`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
 
 - `options`: _array_ of _strings_ - list of tracing options; tracing options are [`trace`, `vmTrace`, and `stateDiff`](../trace-types.md). Specify any combination of the three options including none of them.
 


### PR DESCRIPTION
This PR adds `qbft_getValidatorsByBlockNumber` as a method that supports the `pending` value for block parameter, and adds a description of what `pending` means for `getValidators`. (Fixes #1520)

Also adds note on any methods that include `pending` to specify that `pending` returns the same value as `latest` (except for `eth_getTransactionCount` and `qbft_getValidatorsByBlockNumber`).

Also removes `blockHash` from the block parameter description of methods except those specified as supporting `blockHash` on the [block parameter page](https://besu.hyperledger.org/public-networks/how-to/use-besu-api/json-rpc#block-parameter).