### PR TITLE
Document revert-metadata subcommand

### DIFF
--- a/docs/public-networks/reference/cli/subcommands.md
+++ b/docs/public-networks/reference/cli/subcommands.md
@@ -282,6 +282,23 @@ The command accepts the following command line options:
 
 Provides storage related actions.
 
+### `revert-metadata`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+besu storage revert-metadata v2-to-v1
+```
+
+</TabItem>
+
+</Tabs>
+
+Reverts the modifications made by the [database metadata refactor](https://github.com/hyperledger/besu/pull/6555).
+If you need to downgrade Besu, run this subcommand before installing the previous binaries.
+
 ### `revert-variables`
 
 <Tabs>


### PR DESCRIPTION
This PR documents the `storage revert-metadata v2-to-v1` subcommand for reverting the database metadata refactor. Fixes #1522.

Preview: https://besu-docs-git-fork-alexandratran-1522-databa-437ab6-hyperledger.vercel.app/development/public-networks/reference/cli/subcommands#storage