### PR TITLE
Document Clique transitions

### DIFF
--- a/docs/private-networks/how-to/configure/consensus/add-validators-without-voting.md
+++ b/docs/private-networks/how-to/configure/consensus/add-validators-without-voting.md
@@ -27,11 +27,10 @@ To add or remove validators without voting:
     - `<BlockNumber>` is the upcoming block at which to change validators.
     - `<ValidatorAddressX> ... <ValidatorAddressZ>` are strings representing the account addresses of the validators after `<BlockNumber>`.
 
-<Tabs>
+    <Tabs>
+    <TabItem value="QBFT syntax" label="QBFT syntax" default>
 
-<TabItem value="QBFT syntax" label="QBFT syntax" default>
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -57,11 +56,10 @@ To add or remove validators without voting:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    <TabItem value="QBFT example" label="QBFT example">
 
-<TabItem value="QBFT example" label="QBFT example">
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -86,9 +84,10 @@ To add or remove validators without voting:
     }
     ```
 
-    # IBFT 2.0 syntax
+    </TabItem>
+    <TabItem value="IBFT 2.0 syntax">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -114,9 +113,10 @@ To add or remove validators without voting:
     }
     ```
 
-    # IBFT 2.0 example
+    </TabItem>
+    <TabItem value="IBFT 2.0 example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -141,9 +141,8 @@ To add or remove validators without voting:
     }
     ```
 
-</TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
 
 2.  Restart all nodes in the network using the updated genesis file. You can make a rolling update of the nodes, as long as they're all up before the transition block is processed.
 3.  To verify the changes after the transition block, call [`qbft_getValidatorsByBlockNumber`](../../../reference/api/index.md#qbft_getvalidatorsbyblocknumber) or [`ibft_getValidatorsByBlockNumber`](../../../reference/api/index.md#ibft_getvalidatorsbyblocknumber), specifying `latest`.
@@ -164,17 +163,16 @@ This requires temporarily [switching to block header validator selection mode](q
 
 To bypass the smart contract and specify new validators:
 
-1.  In the genesis file, add a `transitions` configuration item where:
+1. In the genesis file, add a `transitions` configuration item where:
 
     - `<BlockNumber>` is the upcoming block at which to change validators.
     - `<SelectionMode>` is the validator selection mode to switch to. In this case we'll switch to the `blockheader` mode temporarily.
     - `<ValidatorAddressX> ... <ValidatorAddressZ>` are strings representing the account addresses of the validators after `<BlockNumber>`. These validators only need to be sufficient to progress the chain and allow a new contract to be deployed.
 
-<Tabs>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
-<TabItem value="Syntax" label="Syntax" default>
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -202,11 +200,10 @@ To bypass the smart contract and specify new validators:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
-<TabItem value="Example" label="Example">
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -233,23 +230,21 @@ To bypass the smart contract and specify new validators:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    </Tabs>
 
-</Tabs>
-
-1.  Restart all nodes in the network using the updated genesis file. You can make a rolling update of the nodes, as long as they're all up before the transition block is processed.
-1.  Deploy a new contract to the blockchain containing the desired list of validators.
-1.  In the genesis file, add another `transitions` configuration item where:
+2. Restart all nodes in the network using the updated genesis file. You can make a rolling update of the nodes, as long as they're all up before the transition block is processed.
+3. Deploy a new contract to the blockchain containing the desired list of validators.
+4. In the genesis file, add another `transitions` configuration item where:
 
     - `<BlockNumber>` is the upcoming block at which to change validators.
     - `<SelectionMode>` is the validator selection mode to switch to. In this case we'll switch to `contract` mode.
     - `<NewValidatorContractAddress>` is the address of the new smart contract.
 
-<Tabs>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
-<TabItem value="Syntax" label="Syntax" default>
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -281,11 +276,10 @@ To bypass the smart contract and specify new validators:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
-<TabItem value="Example" label="Example">
-
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -317,8 +311,7 @@ To bypass the smart contract and specify new validators:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    </Tabs>
 
-</Tabs>
-
-1.  Restart all nodes in the network using the updated genesis file. You can make a rolling update of the nodes, as long as they're all up before the transition block is processed.
+5. Restart all nodes in the network using the updated genesis file. You can make a rolling update of the nodes, as long as they're all up before the transition block is processed.

--- a/docs/private-networks/how-to/configure/consensus/clique.md
+++ b/docs/private-networks/how-to/configure/consensus/clique.md
@@ -8,6 +8,9 @@ tags:
   - private networks
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Configure Clique consensus
 
 Besu implements the [Clique](https://eips.ethereum.org/EIPS/eip-225) proof of authority (PoA) [consensus protocol](index.md). Private networks can use Clique.
@@ -35,7 +38,8 @@ A Clique genesis file defines properties specific to Clique.
     "berlinBlock": 0,
     "clique": {
       "blockperiodseconds": 15,
-      "epochlength": 30000
+      "epochlength": 30000,
+      "createemptyblocks": true
     }
   },
   "coinbase": "0x0000000000000000000000000000000000000000",
@@ -102,13 +106,13 @@ The `extraData` property consists of:
 
 After [The Merge](../../../../public-networks/concepts/the-merge.md), the following block fields are modified or deprecated. Their fields **must** contain only the constant values from the following chart.
 
-| Field | Constant value | Comment |
-| --- | --- | --- |
-| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
-| **`difficulty`** | `0` | Replaced with `prevrandao` |
-| **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
-| **`nonce`** | `0x0000000000000000` |  |
-| **`ommers`** | `[]` | `RLP([]) = 0xc0` |
+| Field            | Constant value                                                       | Comment                    |
+|------------------|----------------------------------------------------------------------|----------------------------|
+| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))`     |
+| **`difficulty`** | `0`                                                                  | Replaced with `prevrandao` |
+| **`mixHash`**    | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
+| **`nonce`**      | `0x0000000000000000`                                                 |                            |
+| **`ommers`**     | `[]`                                                                 | `RLP([]) = 0xc0`           |
 
 Additionally, [`extraData`](#extra-data) is limited to 32 bytes of vanity data after The Merge.
 
@@ -163,6 +167,92 @@ The process for removing a signer from a Clique network is the same as [adding a
 At each epoch transition, Clique discards all pending votes collected from received blocks. Existing proposals remain in effect and signers re-add their vote the next time they create a block.
 
 Define the number of blocks between epoch transitions in the [Clique genesis file](#genesis-file).
+
+## Transitions
+
+The `transitions` genesis configuration item allows you to specify a future block number at which to
+change the Clique network configuration in an existing network.
+For example, you can update the [block time](#configure-block-time-on-an-existing-network).
+
+:::caution
+Do not specify a transition block in the past.
+Specifying a transition block in the past can result in unexpected behavior, such as causing the
+network to fork.
+:::
+
+### Configure block time on an existing network
+
+To update an existing network with a new `blockperiodseconds`:
+
+1. Stop all nodes in the network.
+2. In the [genesis file](#genesis-file), add the `transitions` configuration item where:
+
+    - `<FutureBlockNumber>` is the upcoming block at which to change `blockperiodseconds`.
+    - `<NewValue>` is the updated value for `blockperiodseconds`.
+
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
+
+    ```bash
+    {
+      "config": {
+        ...
+        "clique": {
+          "blockperiodseconds": 3,
+          "epochlength": 30,
+          "requesttimeoutseconds": 6,
+          "createemptyblocks": true
+        },
+        "transitions": {
+          "clique": [
+            {
+              "block": <FutureBlockNumber>,
+              "blockperiodseconds": <NewValue>
+            }
+          ]
+        }
+      },
+      ...
+    }
+    ```
+
+    </TabItem>
+    <TabItem value="Example" label="Example">
+
+    ```bash
+    {
+      "config": {
+        ...
+        "clique": {
+          "blockperiodseconds": 3,
+          "epochlength": 30,
+          "requesttimeoutseconds": 6,
+          "createemptyblocks": true
+        },
+        "transitions": {
+          "clique": [
+            {
+              "block": 3,
+              "blockperiodseconds": 1
+            },
+            {
+              "block": 6,
+              "blockperiodseconds": 2
+            },
+          ]
+        }
+      },
+      ...
+    }
+    ```
+
+    </TabItem>
+    </Tabs>
+
+3. Restart all nodes in the network using the updated genesis file.
+4. To verify the changes after the transition block, call
+   [`clique_getSigners`](../../../reference/api/index.md#clique_getsigners),
+   specifying `latest`.
 
 ## Limitations
 

--- a/docs/private-networks/how-to/configure/consensus/clique.md
+++ b/docs/private-networks/how-to/configure/consensus/clique.md
@@ -69,7 +69,7 @@ By default, Clique creates empty blocks. For large private networks using Clique
 
 To skip creating empty blocks, set `createemptyblocks` to `false` in the genesis file: 
 
-```bash
+```json
 {
   "config": {
     "londonBlock": 0,
@@ -172,7 +172,8 @@ Define the number of blocks between epoch transitions in the [Clique genesis fil
 
 The `transitions` genesis configuration item allows you to specify a future block number at which to
 change the Clique network configuration in an existing network.
-For example, you can update the [block time](#configure-block-time-on-an-existing-network).
+For example, you can update the [block time](#configure-block-time-on-an-existing-network) and
+whether to [create empty blocks](#configure-empty-blocks-on-an-existing-network).
 
 :::caution
 Do not specify a transition block in the past.
@@ -193,7 +194,7 @@ To update an existing network with a new `blockperiodseconds`:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -219,7 +220,7 @@ To update an existing network with a new `blockperiodseconds`:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -250,9 +251,75 @@ To update an existing network with a new `blockperiodseconds`:
     </Tabs>
 
 3. Restart all nodes in the network using the updated genesis file.
-4. To verify the changes after the transition block, call
-   [`clique_getSigners`](../../../reference/api/index.md#clique_getsigners),
-   specifying `latest`.
+4. To verify the changes after the transition block, view the Besu logs and check that the time
+   difference between each block matches the updated block period.
+
+### Configure empty blocks on an existing network
+
+To update an existing network with a new [`createemptyblocks`](#skip-empty-blocks):
+
+1. Stop all nodes in the network.
+2. In the [genesis file](#genesis-file), add the `transitions` configuration item where:
+
+    - `<FutureBlockNumber>` is the upcoming block at which to change `createemptyblocks`.
+    - `<NewValue>` is the updated value for `createemptyblocks`.
+
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
+
+    ```json
+    {
+      "config": {
+        ...
+        "clique": {
+          "blockperiodseconds": 3,
+          "epochlength": 30,
+          "requesttimeoutseconds": 6,
+          "createemptyblocks": true
+        },
+        "transitions": {
+          "clique": [
+            {
+              "block": <FutureBlockNumber>,
+              "createemptyblocks": <NewValue>
+            }
+          ]
+        }
+      },
+      ...
+    }
+    ```
+
+    </TabItem>
+    <TabItem value="Example" label="Example">
+
+    ```json
+    {
+      "config": {
+        ...
+        "clique": {
+          "blockperiodseconds": 3,
+          "epochlength": 30,
+          "requesttimeoutseconds": 6,
+          "createemptyblocks": true
+        },
+        "transitions": {
+          "clique": [
+            {
+              "block": 10,
+              "createemptyblocks": false
+            }
+          ]
+        }
+      },
+      ...
+    }
+    ```
+
+    </TabItem>
+    </Tabs>
+
+3. Restart all nodes in the network using the updated genesis file.
 
 ## Limitations
 

--- a/docs/private-networks/how-to/configure/consensus/ibft.md
+++ b/docs/private-networks/how-to/configure/consensus/ibft.md
@@ -174,13 +174,13 @@ Optional configuration options in the genesis file are:
 
 After [The Merge](../../../../public-networks/concepts/the-merge.md), the following block fields are modified or deprecated. Their fields **must** contain only the constant values from the following chart.
 
-| Field | Constant value | Comment |
-| --- | --- | --- |
-| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
-| **`difficulty`** | `0` | Replaced with `prevrandao` |
-| **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
-| **`nonce`** | `0x0000000000000000` |  |
-| **`ommers`** | `[]` | `RLP([]) = 0xc0` |
+| Field            | Constant value                                                       | Comment                    |
+|------------------|----------------------------------------------------------------------|----------------------------|
+| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))`     |
+| **`difficulty`** | `0`                                                                  | Replaced with `prevrandao` |
+| **`mixHash`**    | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
+| **`nonce`**      | `0x0000000000000000`                                                 |                            |
+| **`ommers`**     | `[]`                                                                 | `RLP([]) = 0xc0`           |
 
 Additionally, [`extraData`](#extra-data) is limited to 32 bytes of vanity data after The Merge.
 
@@ -250,27 +250,30 @@ Non-validator nodes don't affect performance and don't count towards the maximum
 
 ## Transitions
 
-The `transitions` genesis configuration item allows you to specify a future block number at which to change IBFT 2.0 network configuration in an existing network. For example, you can update the [block time](#configure-block-time-on-an-existing-network-deployment), [block reward](#configure-block-rewards-on-an-existing-network-deployment), or [mining beneficiary](#configure-the-mining-beneficiary-on-an-existing-network-deployment).
+The `transitions` genesis configuration item allows you to specify a future block number at which to
+change the IBFT 2.0 network configuration in an existing network.
+For example, you can update the [block time](#configure-block-time-on-an-existing-network),
+[block reward](#configure-block-rewards-on-an-existing-network), or
+[mining beneficiary](#configure-the-mining-beneficiary-on-an-existing-network).
 
 :::caution
-
-Do not specify a transition block in the past. Specifying a transition block in the past could result in unexpected behavior, such as causing the network to fork.
-
+Do not specify a transition block in the past.
+Specifying a transition block in the past can result in unexpected behavior, such as causing the
+network to fork.
 :::
 
-### Configure block time on an existing network deployment
+### Configure block time on an existing network
 
 To update an existing network with a new `blockperiodseconds`:
 
-1.  Stop all nodes in the network.
-1.  In the [genesis file](#genesis-file), add the `transitions` configuration item where:
+1. Stop all nodes in the network.
+2. In the [genesis file](#genesis-file), add the `transitions` configuration item where:
 
     - `<FutureBlockNumber>` is the upcoming block at which to change `blockperiodseconds`.
     - `<NewValue>` is the updated value for `blockperiodseconds`.
 
-<Tabs>
-
-<TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -294,9 +297,8 @@ To update an existing network with a new `blockperiodseconds`:
     }
     ```
 
-</TabItem>
-
-<TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -320,25 +322,26 @@ To update an existing network with a new `blockperiodseconds`:
     }
     ```
 
-</TabItem>
+    </TabItem>
+    </Tabs>
 
-</Tabs>
-1.  Restart all nodes in the network using the updated genesis file.
-1.  To verify the changes after the transition block, call [`ibft_getValidatorsByBlockNumber`](../../../../public-networks/reference/api/index.md#ibft_getvalidatorsbyblocknumber), specifying `latest`.
+3. Restart all nodes in the network using the updated genesis file.
+4. To verify the changes after the transition block, call
+   [`ibft_getValidatorsByBlockNumber`](../../../reference/api/index.md#ibft_getvalidatorsbyblocknumber),
+   specifying `latest`.
 
-### Configure block rewards on an existing network deployment
+### Configure block rewards on an existing network
 
 To update an existing network with a new `blockreward`:
 
-1.  Stop all nodes in the network.
-1.  In the [genesis file](#genesis-file), add the `transitions` configuration item where:
+1. Stop all nodes in the network.
+2. In the [genesis file](#genesis-file), add the `transitions` configuration item where:
 
     - `<FutureBlockNumber>` is the upcoming block at which to change `blockreward`.
     - `<NewValue>` is the updated value for `blockreward`.
 
-<Tabs>
-
-  <TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -371,9 +374,8 @@ To update an existing network with a new `blockreward`:
     }
     ```
 
-  </TabItem>
-
-  <TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -406,30 +408,29 @@ To update an existing network with a new `blockreward`:
     }
     ```
 
-  </TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
+    
     :::note
 
     You can add multiple `blockreward` updates in one transition object by specifying multiple future blocks.
 
     :::
 
-1.  Restart all nodes in the network using the updated genesis file.
+3. Restart all nodes in the network using the updated genesis file.
 
-### Configure the mining beneficiary on an existing network deployment
+### Configure the mining beneficiary on an existing network
 
 To update an existing network with a new mining beneficiary:
 
-1.  Stop all nodes in the network.
-1.  In the [genesis file](#genesis-file), add the `transitions` configuration item where:
+1. Stop all nodes in the network.
+2. In the [genesis file](#genesis-file), add the `transitions` configuration item where:
 
     - `<FutureBlockNumber>` is the upcoming block at which to change `miningbeneficiary`.
     - `<NewAddress>` is the updated 20-byte address for `miningbeneficiary`. Starting at `<FutureBlockNumber>`, block rewards go to this address.
 
-<Tabs>
-
-  <TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -460,9 +461,8 @@ To update an existing network with a new mining beneficiary:
     }
     ```
 
-  </TabItem>
-
-  <TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -493,21 +493,13 @@ To update an existing network with a new mining beneficiary:
     }
     ```
 
-  </TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
+    
     :::note
 
     Setting the `miningbeneficiary` to an empty value clears out any override so that block rewards go to the block producer rather than a global override address.
 
     :::
 
-1.  Restart all nodes in the network using the updated genesis file.
-
-<!-- Acronyms and Definitions -->
-
-_[vanity data]: Validators can include anything they like as vanity data. _[RLP]: Recursive Length Prefix
-
-```
-
-```
+3. Restart all nodes in the network using the updated genesis file.

--- a/docs/private-networks/how-to/configure/consensus/ibft.md
+++ b/docs/private-networks/how-to/configure/consensus/ibft.md
@@ -275,7 +275,7 @@ To update an existing network with a new `blockperiodseconds`:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -300,7 +300,7 @@ To update an existing network with a new `blockperiodseconds`:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -326,9 +326,8 @@ To update an existing network with a new `blockperiodseconds`:
     </Tabs>
 
 3. Restart all nodes in the network using the updated genesis file.
-4. To verify the changes after the transition block, call
-   [`ibft_getValidatorsByBlockNumber`](../../../reference/api/index.md#ibft_getvalidatorsbyblocknumber),
-   specifying `latest`.
+4. To verify the changes after the transition block, view the Besu logs and check that the time
+   difference between each block matches the updated block period.
 
 ### Configure block rewards on an existing network
 
@@ -343,7 +342,7 @@ To update an existing network with a new `blockreward`:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -377,7 +376,7 @@ To update an existing network with a new `blockreward`:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -432,7 +431,7 @@ To update an existing network with a new mining beneficiary:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         "chainId": 999,
@@ -464,7 +463,7 @@ To update an existing network with a new mining beneficiary:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         "chainId": 999,

--- a/docs/private-networks/how-to/configure/consensus/qbft.md
+++ b/docs/private-networks/how-to/configure/consensus/qbft.md
@@ -417,7 +417,7 @@ To update an existing network with a new `blockperiodseconds`:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -442,7 +442,7 @@ To update an existing network with a new `blockperiodseconds`:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -468,9 +468,8 @@ To update an existing network with a new `blockperiodseconds`:
     </Tabs>
 
 3.  Restart all nodes in the network using the updated genesis file.
-4.  To verify the changes after the transition block, call
-    [`qbft_getValidatorsByBlockNumber`](../../../reference/api/index.md#qbft_getvalidatorsbyblocknumber),
-    specifying `latest`.
+4.  To verify the changes after the transition block, view the Besu logs and check that the time
+    difference between each block matches the updated block period.
 
 ### Configure block rewards on an existing network
 
@@ -485,7 +484,7 @@ To update an existing network with a new `blockreward`:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -519,7 +518,7 @@ To update an existing network with a new `blockreward`:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -575,7 +574,7 @@ To swap between block header validator selection and contract validator selectio
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -601,7 +600,7 @@ To swap between block header validator selection and contract validator selectio
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -642,7 +641,7 @@ To update an existing network with a new mining beneficiary:
     <Tabs>
     <TabItem value="Syntax" label="Syntax" default>
 
-    ```bash
+    ```json
     {
       "config": {
         ...
@@ -671,7 +670,7 @@ To update an existing network with a new mining beneficiary:
     </TabItem>
     <TabItem value="Example" label="Example">
 
-    ```bash
+    ```json
     {
       "config": {
         ...

--- a/docs/private-networks/how-to/configure/consensus/qbft.md
+++ b/docs/private-networks/how-to/configure/consensus/qbft.md
@@ -199,7 +199,10 @@ When using block header validator selection, the important information in the ge
 
 :::info
 
-When using contract validator selection to manage validators, the list of validators is configured in the `alloc` property's `storage` section. View the example smart contract for more information on how to generate the `storage` section.
+When using contract validator selection to manage validators, the list of validators is configured
+in the `alloc` property's `storage` section.
+View the [example smart contract](https://github.com/ConsenSys/validator-smart-contracts) for more
+information on how to generate the `storage` section.
 
 :::
 
@@ -286,13 +289,13 @@ Optional configuration options in the genesis file are:
 
 After [The Merge](../../../../public-networks/concepts/the-merge.md), the following block fields are modified or deprecated. Their fields **must** contain only the constant values from the following chart.
 
-| Field | Constant value | Comment |
-| --- | --- | --- |
-| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
-| **`difficulty`** | `0` | Replaced with `prevrandao` |
-| **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
-| **`nonce`** | `0x0000000000000000` |  |
-| **`ommers`** | `[]` | `RLP([]) = 0xc0` |
+| Field            | Constant value                                                       | Comment                    |
+|------------------|----------------------------------------------------------------------|----------------------------|
+| **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))`     |
+| **`difficulty`** | `0`                                                                  | Replaced with `prevrandao` |
+| **`mixHash`**    | `0x0000000000000000000000000000000000000000000000000000000000000000` | Replaced with `prevrandao` |
+| **`nonce`**      | `0x0000000000000000`                                                 |                            |
+| **`ommers`**     | `[]`                                                                 | `RLP([]) = 0xc0`           |
 
 Additionally, [`extraData`](#extra-data) is limited to the 32 bytes of vanity data after The Merge.
 
@@ -388,12 +391,17 @@ QBFT requires four validators to be Byzantine fault tolerant. Byzantine fault to
 
 ## Transitions
 
-The `transitions` genesis configuration item allows you to specify a future block number at which to change QBFT network configuration in an existing network. For example, you can update the [block time](#configure-block-time-on-an-existing-network), [block reward](#configure-block-rewards-on-an-existing-network-deployment), [validator management method](#swap-validator-management-methods), or [mining beneficiary](#configure-the-mining-beneficiary-on-an-existing-network-deployment).
+The `transitions` genesis configuration item allows you to specify a future block number at which to 
+the QBFT network configuration in an existing network.
+For example, you can update the [block time](#configure-block-time-on-an-existing-network),
+[block reward](#configure-block-rewards-on-an-existing-network),
+[validator management method](#swap-validator-management-methods), or
+[mining beneficiary](#configure-the-mining-beneficiary-on-an-existing-network).
 
 :::caution
-
-Do not specify a transition block in the past. Specifying a transition block in the past could result in unexpected behavior, such as causing the network to fork.
-
+Do not specify a transition block in the past.
+Specifying a transition block in the past can result in unexpected behavior, such as causing the
+network to fork.
 :::
 
 ### Configure block time on an existing network
@@ -406,9 +414,8 @@ To update an existing network with a new `blockperiodseconds`:
     - `<FutureBlockNumber>` is the upcoming block at which to change `blockperiodseconds`.
     - `<NewValue>` is the updated value for `blockperiodseconds`.
 
-<Tabs>
-
-<TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -433,8 +440,7 @@ To update an existing network with a new `blockperiodseconds`:
     ```
 
     </TabItem>
-
-<TabItem value="Example" label="Example">
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -458,14 +464,15 @@ To update an existing network with a new `blockperiodseconds`:
     }
     ```
 
-</TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
 
 3.  Restart all nodes in the network using the updated genesis file.
-4.  To verify the changes after the transition block, call [`qbft_getValidatorsByBlockNumber`](../../../reference/api/index.md#ibft_getvalidatorsbyblocknumber), specifying `latest`.
+4.  To verify the changes after the transition block, call
+    [`qbft_getValidatorsByBlockNumber`](../../../reference/api/index.md#qbft_getvalidatorsbyblocknumber),
+    specifying `latest`.
 
-### Configure block rewards on an existing network deployment
+### Configure block rewards on an existing network
 
 To update an existing network with a new `blockreward`:
 
@@ -475,9 +482,8 @@ To update an existing network with a new `blockreward`:
     - `<FutureBlockNumber>` is the upcoming block at which to change `blockreward`.
     - `<NewValue>` is the updated value for `blockreward`.
 
-<Tabs>
-
-<TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -510,9 +516,8 @@ To update an existing network with a new `blockreward`:
     }
     ```
 
-</TabItem>
-
-<TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -545,9 +550,8 @@ To update an existing network with a new `blockreward`:
     }
     ```
 
-</TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
 
     :::note
 
@@ -568,9 +572,8 @@ To swap between block header validator selection and contract validator selectio
     - `<SelectionMode>` is the validator selection mode to switch to. Valid options are `contract` and `blockheader`.
     - `<ContractAddress>` is the smart contract address, if switching to the contract validator selection method.
 
-<Tabs>
-
-<TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -595,9 +598,8 @@ To swap between block header validator selection and contract validator selectio
     }
     ```
 
-</TabItem>
-
-<TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -622,13 +624,12 @@ To swap between block header validator selection and contract validator selectio
     }
     ```
 
-</TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
 
 3.  Restart all nodes in the network using the updated genesis file.
 
-### Configure the mining beneficiary on an existing network deployment
+### Configure the mining beneficiary on an existing network
 
 To update an existing network with a new mining beneficiary:
 
@@ -638,9 +639,8 @@ To update an existing network with a new mining beneficiary:
     - `<FutureBlockNumber>` is the upcoming block at which to change `miningbeneficiary`.
     - `<NewAddress>` is the updated 20-byte address for `miningbeneficiary`. Starting at `<FutureBlockNumber>`, block rewards go to this address.
 
-<Tabs>
-
-<TabItem value="Syntax" label="Syntax" default>
+    <Tabs>
+    <TabItem value="Syntax" label="Syntax" default>
 
     ```bash
     {
@@ -668,9 +668,8 @@ To update an existing network with a new mining beneficiary:
     }
     ```
 
-</TabItem>
-
-<TabItem value="Example" label="Example">
+    </TabItem>
+    <TabItem value="Example" label="Example">
 
     ```bash
     {
@@ -698,9 +697,8 @@ To update an existing network with a new mining beneficiary:
     }
     ```
 
-</TabItem>
-
-</Tabs>
+    </TabItem>
+    </Tabs>
 
     :::note
 
@@ -709,10 +707,3 @@ To update an existing network with a new mining beneficiary:
     :::
 
 3.  Restart all nodes in the network using the updated genesis file.
-
-<!-- Acronyms and Definitions -->
-
-_[vanity data]: Validators can include anything they like as vanity data. _[RLP]: Recursive Length Prefix
-
-[GoQuorum]: https://consensys.net/docs/goquorum/en/stable/
-[View the example smart contract]: https://github.com/ConsenSys/validator-smart-contracts


### PR DESCRIPTION
Document Clique block period and empty blocks transitions. Also fix some formatting and link issues on the QBFT and IBFT transition sections.

Fixes #1528
Fixes #1531 

Preview: https://besu-docs-f8rvwdpjq-hyperledger.vercel.app/development/private-networks/how-to/configure/consensus/clique#transitions