### PR TITLE
Add additional miner methods

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6603,7 +6603,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setMinGasPrice","params":[
 
 ### `miner_setMinPriorityFee`
 
-Sets the minimum priority fee per gas (in wei) offered by a transaction to be included in a block. The initial value is set using the [`--min-priority-fee`](../cli/options.md#min-priority-fee) command line option, or is set to `0` if the command line option is not specified.
+Sets the minimum priority fee per gas (in wei) offered by a transaction to be included in a block. 
+The initial value is set using the [`--min-priority-fee`](../cli/options.md#min-priority-fee) command line option, or is set to `0` if the command line option is not specified.
 Use [`miner_getMinPriorityFee`](#miner_getminpriorityfee) to get the current value of the fee.
 
 #### Parameters
@@ -6653,7 +6654,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setMinPriorityFee","params
 
 ### `miner_start`
 
-Starts the mining process. To start mining, you must first specify a miner coinbase using the [`--miner-coinbase`](../cli/options.md#miner-coinbase) command line option or using [`miner_setCoinbase`](#miner_setcoinbase).
+Starts the mining process. 
+To start mining, you must first specify a miner coinbase using the [`--miner-coinbase`](../cli/options.md#miner-coinbase) command line option or using [`miner_setCoinbase`](#miner_setcoinbase).
 
 #### Parameters
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6297,7 +6297,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 
 ### `miner_getExtraData`
 
-Retrieves the current extra data field from the mining node.
+Retrieves the current extra data field that is used when producing blocks.
 
 #### Parameters
 
@@ -6305,7 +6305,7 @@ None
 
 #### Returns
 
-`result`: _string_ - Hexadecimal string of the extra data bytes.
+`result`: _string_ - Hexadecimal string representation of the extra data bytes.
 
 <Tabs>
 
@@ -6505,7 +6505,7 @@ Sets a new value for the extra data field that is used when producing blocks.
 
 #### Parameters
 
-`extraData`: _string_ - Hexadecimal with a maximum 32 bytes.
+`extraData`: _string_ - Hexadecimal representation of a block number, with a maximum of 32 bytes.
 
 #### Returns
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6238,7 +6238,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_uninstallFilter","params":["
 ## `MINER` methods
 
 The `MINER` API methods allow you to control the node's mining operation, or settings related to
-block creation in general.
+block creation in general. 
 
 :::note
 
@@ -6305,7 +6305,7 @@ None
 
 #### Returns
 
-`result`: _string_ - Hexadecimal or decimal integer of the extra data bytes.
+`result`: _string_ - Hexadecimal string of the extra data bytes.
 
 <Tabs>
 
@@ -6501,9 +6501,11 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setCoinbase","params":["0x
 
 ### `miner_setExtraData`
 
-Sets a new value for the extra data field on the mining node.
+Sets a new value for the extra data field that is used when producing blocks.
 
 #### Parameters
+
+`extraData`: _string_ - Hexadecimal with a maximum 32 bytes.
 
 #### Returns
 
@@ -6514,7 +6516,7 @@ Sets a new value for the extra data field on the mining node.
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setExtraData","params":[], "id":1}' http://127.0.0.1:8545
+curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setExtraData","params":["0x0010203"], "id":1}' http://127.0.0.1:8545
 ```
 
 </TabItem>
@@ -6525,7 +6527,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setExtraData","params":[],
 {
   "jsonrpc": "2.0",
   "method": "miner_setExtraData",
-  "params": [],
+  "params": ["0x0010203"],
   "id": 1
 }
 ```
@@ -6537,6 +6539,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setExtraData","params":[],
 ```json
 {
   "jsonrpc": "2.0",
+  "params": ["0x0010203"],
   "id": 1,
   "result": "true"
 }

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6295,6 +6295,55 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 
 </Tabs>
 
+### `miner_getExtraData`
+
+Updates the target gas limit set using the [`--target-gas-limit`](../cli/options.md#target-gas-limit) command line option.
+
+#### Parameters
+
+`gasPrice`: _number_ - target gas price in wei
+
+#### Returns
+
+`result`: _string_ - `Success` or `error`
+
+<Tabs>
+
+<TabItem value="curl HTTP request" label="curl HTTP request" default>
+
+```bash
+curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","params":[800000], "id":1}' http://127.0.0.1:8545
+```
+
+</TabItem>
+
+<TabItem value="wscat WS request" label="wscat WS request">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "miner_changeTargetGasLimit",
+  "params": [800000],
+  "id": 1
+}
+```
+
+</TabItem>
+
+<TabItem value="JSON result" label="JSON result">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Success"
+}
+```
+
+</TabItem>
+
+</Tabs>
+
 ### `miner_getMinGasPrice`
 
 Gets the minimum gas price (in wei) offered by a transaction to be included in a block.
@@ -6443,6 +6492,55 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setCoinbase","params":["0x
   "jsonrpc": "2.0",
   "id": 1,
   "result": true
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+### `miner_setExtraData`
+
+Updates the target gas limit set using the [`--target-gas-limit`](../cli/options.md#target-gas-limit) command line option.
+
+#### Parameters
+
+`gasPrice`: _number_ - target gas price in wei
+
+#### Returns
+
+`result`: _string_ - `Success` or `error`
+
+<Tabs>
+
+<TabItem value="curl HTTP request" label="curl HTTP request" default>
+
+```bash
+curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","params":[800000], "id":1}' http://127.0.0.1:8545
+```
+
+</TabItem>
+
+<TabItem value="wscat WS request" label="wscat WS request">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "miner_changeTargetGasLimit",
+  "params": [800000],
+  "id": 1
+}
+```
+
+</TabItem>
+
+<TabItem value="JSON result" label="JSON result">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Success"
 }
 ```
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6297,22 +6297,22 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 
 ### `miner_getExtraData`
 
-Updates the target gas limit set using the [`--target-gas-limit`](../cli/options.md#target-gas-limit) command line option.
+Retrieves the current extra data field from the mining node.
 
 #### Parameters
 
-`gasPrice`: _number_ - target gas price in wei
+None
 
 #### Returns
 
-`result`: _string_ - `Success` or `error`
+`result`: _string_ - Hexadecimal or decimal integer of the extra data bytes.
 
 <Tabs>
 
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","params":[800000], "id":1}' http://127.0.0.1:8545
+curl -X POST --data '{"jsonrpc":"2.0","method":"miner_getExtraData","params":[], "id":1}' http://127.0.0.1:8545
 ```
 
 </TabItem>
@@ -6322,8 +6322,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "miner_changeTargetGasLimit",
-  "params": [800000],
+  "method": "miner_getExtraData",
+  "params": [],
   "id": 1
 }
 ```
@@ -6336,7 +6336,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "Success"
+  "result": "0x68656c6c6f20776f726c64"
 }
 ```
 
@@ -6501,22 +6501,20 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setCoinbase","params":["0x
 
 ### `miner_setExtraData`
 
-Updates the target gas limit set using the [`--target-gas-limit`](../cli/options.md#target-gas-limit) command line option.
+Sets a new value for the extra data field on the mining node.
 
 #### Parameters
 
-`gasPrice`: _number_ - target gas price in wei
-
 #### Returns
 
-`result`: _string_ - `Success` or `error`
+`result`: _string_ - `true` or `false`
 
 <Tabs>
 
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","params":[800000], "id":1}' http://127.0.0.1:8545
+curl -X POST --data '{"jsonrpc":"2.0","method":"miner_setExtraData","params":[], "id":1}' http://127.0.0.1:8545
 ```
 
 </TabItem>
@@ -6526,8 +6524,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "miner_changeTargetGasLimit",
-  "params": [800000],
+  "method": "miner_setExtraData",
+  "params": [],
   "id": 1
 }
 ```
@@ -6540,7 +6538,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"miner_changeTargetGasLimit","par
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "Success"
+  "result": "true"
 }
 ```
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -6505,7 +6505,7 @@ Sets a new value for the extra data field that is used when producing blocks.
 
 #### Parameters
 
-`extraData`: _string_ - Hexadecimal representation of a block number, with a maximum of 32 bytes.
+`extraData`: _string_ - Hexadecimal representation of the extra data field, with a maximum of 32 bytes.
 
 #### Returns
 


### PR DESCRIPTION
Fixes #1592 

Add miner methods:

* `miner_getExtraData` request has no parameters, and the response is the hex string of the extra data bytes

* `miner_setExtraData` request has only 1 parameter: the hex string of the extra data bytes.
