### PR TITLE
Clarify that snap is faster than fast sync

### DIFF
--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -82,7 +82,7 @@ Snap sync and checkpoint sync are not supported for
 
 :::tip
 
-We recommend using snap sync over fast sync because snap sync can be faster by several days.
+We recommend using snap sync over fast sync because snap sync can be faster than fast sync by several days (for mainnet).
 
 We recommend using snap sync with the [Bonsai](../../concepts/data-storage-formats.md#bonsai-tries)
 data storage format for the fastest sync and lowest storage requirements.

--- a/docs/public-networks/get-started/connect/sync-node.md
+++ b/docs/public-networks/get-started/connect/sync-node.md
@@ -82,7 +82,7 @@ Snap sync and checkpoint sync are not supported for
 
 :::tip
 
-We recommend using snap sync over fast sync because snap sync can be faster than fast sync by several days (for mainnet).
+We recommend using snap sync over fast sync because snap sync can be faster than fast sync by several days (for Mainnet).
 
 We recommend using snap sync with the [Bonsai](../../concepts/data-storage-formats.md#bonsai-tries)
 data storage format for the fastest sync and lowest storage requirements.


### PR DESCRIPTION
User raised a [question](https://discord.com/channels/905194001349627914/1129455688255553717/1247277719968940046) on discord about snap being faster than checkpoint. I think it makes sense to clarify that it's faster than fast sync