### PR TITLE
Document logging invalid txs

### DIFF
--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -77,7 +77,7 @@ Use the log marker `INVALID_TX_REMOVED` and the following fields to format the l
 - `reason` - The reason the transaction is invalid.
 - `txrlp` - The RLP encoding of the transaction.
 
-For example, the following Log4j 2 configuration enables logging invalid transactions:
+For example, the following Log4j 2 configuration enables logging of invalid transactions:
 
 ```xml title="debug.xml"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -113,7 +113,7 @@ For example, the following Log4j 2 configuration enables logging invalid transac
 
 ### Log rotation
 
-[Quorum Developer Quickstart](https://github.com/ConsenSys/quorum-dev-quickstart) logging configuration defines a [log rotation to restrict the size of the log files].
+The [Quorum Developer Quickstart](https://github.com/ConsenSys/quorum-dev-quickstart) logging configuration defines a [log rotation to restrict the size of the log files].
 
 <!-- Links -->
 

--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -32,7 +32,7 @@ Use the [`admin_changeLogLevel`](../../reference/api/index.md#admin_changeloglev
 
 ## Advanced logging
 
-You can provide your own logging configuration using the standard Log4j 2 configuration mechanisms. For example, the following Log4j 2 configuration is the same as the [default configuration] except for the exclusion of logging of stack traces for exceptions.
+You can provide your own logging configuration using the standard Log4j 2 configuration mechanisms. For example, the following Log4j 2 configuration is the same as the [default configuration] except for the exclusion of logging of stack traces for exceptions:
 
 ```xml title="debug.xml"
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Document how to log invalid transactions using the `INVALID_TX_REMOVED` log marker.

Fixes #1578

Preview: https://besu-docs-git-fork-alexandratran-1578-log4j2-hyperledger.vercel.app/development/public-networks/how-to/monitor/logging#log-invalid-transactions