### PR TITLE
chore: fix typos in api index.md

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -214,7 +214,7 @@ Each index file contains 100000 blocks. The last fragment of blocks less than 10
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{jsonrpc":"2.0","method":"admin_generateLogBloomCache", "params":["0x0", "0x10000"], "id":1}' http://127.0.0.1:8545
+curl -X POST --data '{"jsonrpc":"2.0","method":"admin_generateLogBloomCache", "params":["0x0", "0x10000"], "id":1}' http://127.0.0.1:8545
 ```
 
 </TabItem>


### PR DESCRIPTION
This PR fixes some typos found in the api index.md