### PR TITLE
1577: adds price bump config

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -5174,7 +5174,7 @@ tx-pool-blob-price-bump="25"
 
 </Tabs>
 
-Sets the price bump policy for re-issued blob transactions. Note that a blob transaction can only replace, and be replaced by, a blob transaction. The default is `100%`.
+Sets the price bump policy for re-issued blob transactions as a percentage increase in price. Note that a blob transaction can only replace, and be replaced by, a blob transaction. The default is `100%`.
 
 ### `tx-pool-enable-save-restore`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -5136,6 +5136,46 @@ The default is `layered`.
 Set to `sequenced` to use the [sequenced transaction pool](../../concepts/transactions/pool#sequenced-transaction-pool).
 The default is `sequenced` for the [enterprise/private profile](../../how-to/use-configuration-file/profile#enterpriseprivate-profile).
 
+### `tx-pool-blob-price-bump`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--tx-pool-blob-price-bump=<INTEGER>
+```
+
+</TabItem>
+
+<TabItem value="Example" label="Example">
+
+```bash
+--tx-pool-blob-price-bump=25
+```
+
+</TabItem>
+
+<TabItem value="Environment variable" label="Environment variable">
+
+```bash
+BESU_TX_POOL_BLOB_PRICE_BUMP=25
+```
+
+</TabItem>
+
+<TabItem value="Configuration file" label="Configuration file">
+
+```bash
+tx-pool-blob-price-bump="25"
+```
+
+</TabItem>
+
+</Tabs>
+
+Sets the price bump policy for re-issued blob transactions. Note that a blob transaction can only replace, and be replaced by, a blob transaction. The default is `100%`.
+
 ### `tx-pool-enable-save-restore`
 
 <Tabs>

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -5174,7 +5174,9 @@ tx-pool-blob-price-bump="25"
 
 </Tabs>
 
-Sets the price bump policy for re-issued blob transactions as a percentage increase in price. Note that a blob transaction can only replace, and be replaced by, a blob transaction. The default is `100%`.
+Sets the price bump policy for re-issued blob transactions as a percentage increase in price. 
+A blob transaction can only replace, or be replaced by, another blob transaction.
+The default is `100`.
 
 ### `tx-pool-enable-save-restore`
 


### PR DESCRIPTION
## Description
Blob price bump percentage to replace an already existing transaction blob tx
blob tx can only replace and be replaced by blob tx
Bash: TX_POOL_BLOB_PRICE_BUMP
syntax: --tx-pool-blob-price-bump

### Issue(s) fixed
Fixes #1577 

### Preview
<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

- [Preview](https://besu-docs-git-fork-m4sterbunny-1577-price-bump-hyperledger.vercel.app/development/public-networks/reference/cli/options#tx-pool-blob-price-bump)
