### PR TITLE
Allow version update with workflow dispatch

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -3,20 +3,27 @@ name: Update Version
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
 
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.release.name }}
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Check release name
+      - name: Validate version
         id: version
         run: |
-          # User can input anything so check what is provided as release name
-          echo "${{ github.event.release.name }}" | grep -q -e "^[0-9]*\.[0-9]*\.[0-9]*$" || {
-            echo "Release name [$RELEASE_NAME] is not in expected format '^[0-9]*\.[0-9]*\.[0-9]*$'"
+          # Validate provided version compatible with the format
+          echo "${{ env.VERSION }}" | grep -q -e "^[0-9]*\.[0-9]*\.[0-9]*$" || {
+            echo "Version ["${{ env.VERSION }}"] is not in expected format '^[0-9]*\.[0-9]*\.[0-9]*$'"
             exit 1
           }
 
@@ -32,5 +39,5 @@ jobs:
       - name: Update version
         run: .github/scripts/update-version.sh
         env:
-          VERSION: ${{ github.event.release.name }}
+          VERSION: ${{ env.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -2,7 +2,7 @@ name: Update Version
 
 on:
   release:
-    types: [released]
+    types: ["released"]
   workflow_dispatch:
     inputs:
       version:
@@ -23,7 +23,7 @@ jobs:
         run: |
           # Validate provided version compatible with the format
           echo "${{ env.VERSION }}" | grep -q -e "^[0-9]*\.[0-9]*\.[0-9]*$" || {
-            echo "Version ["${{ env.VERSION }}"] is not in expected format '^[0-9]*\.[0-9]*\.[0-9]*$'"
+            echo "Version [${{ env.VERSION }}] is not in expected format '^[0-9]*\.[0-9]*\.[0-9]*$'"
             exit 1
           }
 


### PR DESCRIPTION
## Description
Was looking to trigger the version update workflow by re-creating the release 24.7.0. However when a release it re-created from the same commit which has been created a release, it does not seems to trigger the even type released. Added workflow_dispatch also to the same workflow so that users can manually trigger the version update if necessary.