### PR TITLE
Remove version update trigger on release

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,8 +1,6 @@
 name: Update Version
 
 on:
-  release:
-    types: ["released"]
   workflow_dispatch:
     inputs:
       version:
@@ -13,7 +11,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.event.release.name }}
+      VERSION: ${{ github.event.inputs.version }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Description
Version update should occur before creating the release otherwise release contain the content of previous version. Removed the version update workflow trigger on release. User need to run the version update workflow manually and merge the PR. Once PR is merged then new release should be created
