### PR TITLE
replaces development redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -340,11 +340,11 @@ const config = {
           },
           {
             from: "/public-networks/how-to/configuration-file",
-            to: "/development/public-networks/how-to/configure-besu",
+            to: "/public-networks/how-to/configure-besu",
           },
           {
             from: "/public-networks/how-to/use-configuration-file",
-            to: "/development/public-networks/how-to/configure-besu",
+            to: "/public-networks/how-to/configure-besu",
           },
           {
             from: "/private-networks/tutorials/permissioning/onchain",


### PR DESCRIPTION
## Description
Development build redirects require "development/"

### Issue(s) fixed
Removes  "development/" to allow redirect to work in prod

Fixes #1644 

### Preview
<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

- 
