### PR TITLE
remove deprecated sync modes X_SNAP and X_CHECKPOINT

### DIFF
--- a/versioned_docs/version-23.10.2/public-networks/get-started/connect/mainnet.md
+++ b/versioned_docs/version-23.10.2/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \

--- a/versioned_docs/version-23.10.2/public-networks/get-started/connect/sync-node.md
+++ b/versioned_docs/version-23.10.2/public-networks/get-started/connect/sync-node.md
@@ -59,11 +59,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -77,7 +77,7 @@ Checkpoint sync is an early access feature.
 
 :::
 
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/versioned_docs/version-23.10.2/public-networks/get-started/start-node.md
+++ b/versioned_docs/version-23.10.2/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/versioned_docs/version-23.10.2/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.10.2/public-networks/reference/cli/options.md
@@ -4527,7 +4527,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4535,7 +4535,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4543,14 +4543,14 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
 - The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).

--- a/versioned_docs/version-23.10.2/public-networks/tutorials/besu-teku-mainnet.md
+++ b/versioned_docs/version-23.10.2/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \

--- a/versioned_docs/version-23.10.3/public-networks/get-started/connect/mainnet.md
+++ b/versioned_docs/version-23.10.3/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \

--- a/versioned_docs/version-23.10.3/public-networks/get-started/connect/sync-node.md
+++ b/versioned_docs/version-23.10.3/public-networks/get-started/connect/sync-node.md
@@ -57,11 +57,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -75,7 +75,7 @@ Checkpoint sync is an early access feature.
 
 :::
 
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/versioned_docs/version-23.10.3/public-networks/get-started/start-node.md
+++ b/versioned_docs/version-23.10.3/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/versioned_docs/version-23.10.3/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.10.3/public-networks/reference/cli/options.md
@@ -4570,7 +4570,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4578,7 +4578,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4586,14 +4586,14 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
 - The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).

--- a/versioned_docs/version-23.10.3/public-networks/tutorials/besu-teku-mainnet.md
+++ b/versioned_docs/version-23.10.3/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \

--- a/versioned_docs/version-23.4.1/public-networks/get-started/connect/mainnet.md
+++ b/versioned_docs/version-23.4.1/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \

--- a/versioned_docs/version-23.4.1/public-networks/get-started/connect/sync-node.md
+++ b/versioned_docs/version-23.4.1/public-networks/get-started/connect/sync-node.md
@@ -59,11 +59,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -77,7 +77,7 @@ Checkpoint sync is an early access feature.
 
 :::
 
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/versioned_docs/version-23.4.1/public-networks/get-started/start-node.md
+++ b/versioned_docs/version-23.4.1/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.4.1/public-networks/reference/cli/options.md
@@ -4395,7 +4395,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4403,7 +4403,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4411,7 +4411,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4419,14 +4419,14 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration File" label="Configuration File">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
 - The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).

--- a/versioned_docs/version-23.4.1/public-networks/tutorials/besu-teku-mainnet.md
+++ b/versioned_docs/version-23.4.1/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \

--- a/versioned_docs/version-23.7.3/public-networks/get-started/connect/mainnet.md
+++ b/versioned_docs/version-23.7.3/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \

--- a/versioned_docs/version-23.7.3/public-networks/get-started/connect/sync-node.md
+++ b/versioned_docs/version-23.7.3/public-networks/get-started/connect/sync-node.md
@@ -59,11 +59,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -77,7 +77,7 @@ Checkpoint sync is an early access feature.
 
 :::
 
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/versioned_docs/version-23.7.3/public-networks/get-started/start-node.md
+++ b/versioned_docs/version-23.7.3/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/versioned_docs/version-23.7.3/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-23.7.3/public-networks/reference/cli/options.md
@@ -4479,7 +4479,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4487,7 +4487,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4495,7 +4495,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4503,14 +4503,14 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
 - The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).

--- a/versioned_docs/version-23.7.3/public-networks/tutorials/besu-teku-mainnet.md
+++ b/versioned_docs/version-23.7.3/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \

--- a/versioned_docs/version-24.1.0/public-networks/get-started/connect/mainnet.md
+++ b/versioned_docs/version-24.1.0/public-networks/get-started/connect/mainnet.md
@@ -58,7 +58,7 @@ Run the following command or specify the options in a [configuration file](../..
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host=0.0.0.0      \

--- a/versioned_docs/version-24.1.0/public-networks/get-started/connect/sync-node.md
+++ b/versioned_docs/version-24.1.0/public-networks/get-started/connect/sync-node.md
@@ -57,11 +57,11 @@ We recommend using snap sync with the [Bonsai](../../concepts/data-storage-forma
 
 :::
 
-Enable snap sync using [`--sync-mode=X_SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
+Enable snap sync using [`--sync-mode=SNAP`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.0 or later to use snap sync.
 
 Instead of downloading the [state trie](../../concepts/data-storage-formats.md) node by node, snap sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.
 
-You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=X_SNAP`.
+You can't switch from fast sync to snap sync. If your node is blocked in the middle of a fast sync, you can start over using snap sync instead by stopping the node, deleting the data directory, and starting over using `--sync-mode=SNAP`.
 
 You can restart Besu during a snap sync in case of hardware or software problems. The sync resumes from the last valid world state and continues to download blocks starting from the last downloaded block.
 
@@ -75,7 +75,7 @@ Checkpoint sync is an early access feature.
 
 :::
 
-Enable checkpoint sync using [`--sync-mode=X_CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
+Enable checkpoint sync using [`--sync-mode=CHECKPOINT`](../../reference/cli/options.md#sync-mode). You need Besu version 22.4.3 or later to use checkpoint sync.
 
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](../../concepts/genesis-file.md).
 

--- a/versioned_docs/version-24.1.0/public-networks/get-started/start-node.md
+++ b/versioned_docs/version-24.1.0/public-networks/get-started/start-node.md
@@ -45,7 +45,7 @@ By default, Besu syncs to the current state of the blockchain using [fast sync](
 - Networks specified using [`--network`](../reference/cli/options.md#network) except for the `dev` development network.
 - Ethereum Mainnet.
 
-We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=X_SNAP`](../reference/cli/options.md#sync-mode).
+We recommend using [snap sync](connect/sync-node.md#snap-synchronization) for a faster sync, by starting Besu with [`--sync-mode=SNAP`](../reference/cli/options.md#sync-mode).
 
 By default, Besu stores data in the [Forest of Tries](../concepts/data-storage-formats.md#forest-of-tries) format. We recommend using [Bonsai Tries](../concepts/data-storage-formats.md#bonsai-tries) for lower storage requirements, by starting Besu with [`--data-storage-format=BONSAI`](../reference/cli/options.md#data-storage-format).
 

--- a/versioned_docs/version-24.1.0/public-networks/reference/cli/options.md
+++ b/versioned_docs/version-24.1.0/public-networks/reference/cli/options.md
@@ -4570,7 +4570,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Example" label="Example">
 
 ```bash
---sync-mode=X_SNAP
+--sync-mode=SNAP
 ```
 
 </TabItem>
@@ -4578,7 +4578,7 @@ Enables or disables replay protection, in accordance with [EIP-155](https://eips
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-BESU_SYNC_MODE=X_SNAP
+BESU_SYNC_MODE=SNAP
 ```
 
 </TabItem>
@@ -4586,14 +4586,14 @@ BESU_SYNC_MODE=X_SNAP
 <TabItem value="Configuration file" label="Configuration file">
 
 ```bash
-sync-mode="X_SNAP"
+sync-mode="SNAP"
 ```
 
 </TabItem>
 
 </Tabs>
 
-The synchronization mode. Use `X_SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `X_CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
+The synchronization mode. Use `SNAP` for [snap sync](../../get-started/connect/sync-node.md#snap-synchronization), `CHECKPOINT` for [checkpoint sync](../../get-started/connect/sync-node.md#checkpoint-synchronization), `FAST` for [fast sync](../../get-started/connect/sync-node.md#fast-synchronization), and `FULL` for [full sync](../../get-started/connect/sync-node.md#run-an-archive-node).
 
 - The default is `FULL` when connecting to a private network by not using the [`--network`](#network) option and specifying the [`--genesis-file`](#genesis-file) option.
 - The default is `FAST` when using the [`--network`](#network) option with named networks, except for the `dev` development network. `FAST` is also the default if running Besu on the default network (Ethereum Mainnet) by specifying neither [network](#network) nor [genesis file](#genesis-file).

--- a/versioned_docs/version-24.1.0/public-networks/tutorials/besu-teku-mainnet.md
+++ b/versioned_docs/version-24.1.0/public-networks/tutorials/besu-teku-mainnet.md
@@ -53,7 +53,7 @@ Run the following command or specify the options in a [configuration file](../ho
 
 ```bash
 besu \
-  --sync-mode=X_SNAP           \
+  --sync-mode=SNAP           \
   --data-storage-format=BONSAI \
   --rpc-http-enabled=true      \
   --rpc-http-host="0.0.0.0"    \

--- a/versioned_docs/version-24.5.0/public-networks/how-to/bonsai-limit-trie-logs.md
+++ b/versioned_docs/version-24.5.0/public-networks/how-to/bonsai-limit-trie-logs.md
@@ -32,7 +32,7 @@ The following commands are examples. Before executing these example commands on 
 1. Stop Besu.
 1. (Optional) Run the Besu trie log prune command. Specify the Bonsai Trie data storage format and the data directory for your Besu database:
     ```bash
-    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=X_SNAP storage x-trie-log prune
+    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=SNAP storage x-trie-log prune
     ```
 1. Start Besu.
 1. Look for `Limit trie logs enabled: retention: 512; prune window: 30000` in your Besu configuration printout at startup.
@@ -187,7 +187,7 @@ You must shut down the Besu client before running the subcommand.
 
 Check that you have specified `--sync-mode`. 
 The default is `--sync-mode=FAST`. 
-Most Mainnet users use `X_SNAP` or `X_CHECKPOINT`. 
+Most Mainnet users use `SNAP` or `CHECKPOINT`. 
 
 ### Cannot run trie log prune
 

--- a/versioned_docs/version-24.5.2/public-networks/how-to/bonsai-limit-trie-logs.md
+++ b/versioned_docs/version-24.5.2/public-networks/how-to/bonsai-limit-trie-logs.md
@@ -32,7 +32,7 @@ The following commands are examples. Before executing these example commands on 
 1. Stop Besu.
 1. (Optional) Run the Besu trie log prune command. Specify the Bonsai Trie data storage format and the data directory for your Besu database:
     ```bash
-    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=X_SNAP storage x-trie-log prune
+    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=SNAP storage x-trie-log prune
     ```
 1. Start Besu.
 1. Look for `Limit trie logs enabled: retention: 512; prune window: 30000` in your Besu configuration printout at startup.
@@ -187,7 +187,7 @@ You must shut down the Besu client before running the subcommand.
 
 Check that you have specified `--sync-mode`. 
 The default is `--sync-mode=FAST`. 
-Most Mainnet users use `X_SNAP` or `X_CHECKPOINT`. 
+Most Mainnet users use `SNAP` or `CHECKPOINT`. 
 
 ### Cannot run trie log prune
 

--- a/versioned_docs/version-24.6.0/public-networks/how-to/bonsai-limit-trie-logs.md
+++ b/versioned_docs/version-24.6.0/public-networks/how-to/bonsai-limit-trie-logs.md
@@ -40,7 +40,7 @@ Before executing these example commands on your node, modify them to apply to yo
 1. Stop Besu.
 1. (Optional) Run the Besu trie log prune command. Specify the Bonsai Trie data storage format and the data directory for your Besu database:
     ```bash
-    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=X_SNAP storage x-trie-log prune
+    sudo /usr/local/bin/besu/bin/besu --data-storage-format=BONSAI --data-path=/var/lib/besu --sync-mode=SNAP storage x-trie-log prune
     ```
 1. Start Besu.
 1. Look for `Limit trie logs enabled: retention: 512; prune window: 30000` in your Besu configuration printout at startup.
@@ -197,7 +197,7 @@ You must shut down the Besu client before running the subcommand.
 
 Check that you have specified `--sync-mode`. 
 The default is `--sync-mode=FAST`. 
-Most Mainnet users use `X_SNAP` or `X_CHECKPOINT`. 
+Most Mainnet users use `SNAP` or `CHECKPOINT`. 
 
 ### Cannot run trie log prune
 


### PR DESCRIPTION
## Description
Replaced X_SNAP with SNAP and X_CHECKPOINT with CHECKPOINT, as per https://github.com/hyperledger/besu/issues/6612
