### PR TITLE
Prepend BESU_ to all environment variables

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -521,7 +521,7 @@ In private networks defined using [`--genesis-file`](#genesis-file) or when usin
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-CACHE_LAST_BLOCKS=2048
+BESU_CACHE_LAST_BLOCKS=2048
 ```
 
 </TabItem>
@@ -4988,7 +4988,7 @@ Static nodes JSON file containing the [static nodes](../../how-to/connect/static
 <TabItem value="Environment variable" label="Environment variable">
 
 ```bash
-STRICT_TX_REPLAY_PROTECTION_ENABLED=false
+BESU_STRICT_TX_REPLAY_PROTECTION_ENABLED=false
 ```
 
 </TabItem>


### PR DESCRIPTION
The Besu code does this automatically by transforming the option name, e.g. --cache-last-blocks -> BESU_CACHE_LAST_BLOCKS