### PR TITLE
Add Ephemery command to documentation

### DIFF
--- a/docs/private-networks/get-started/install/run-docker-image.md
+++ b/docs/private-networks/get-started/install/run-docker-image.md
@@ -6,6 +6,9 @@ tags:
   - private networks
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Run Besu from a Docker image
 
 Besu provides a Docker image to run a Besu node in a Docker container.
@@ -66,9 +69,21 @@ When running in a Docker container, [`--nat-method`](../../../public-networks/ho
 
 You can specify [Besu environment variables](../../../public-networks/reference/cli/options.md#specify-options) with the Docker image instead of the command line options.
 
-```bash
-docker run -p 30303:30303 -p 8545:8545 -e BESU_RPC_HTTP_ENABLED=true -e BESU_NETWORK=holesky hyperledger/besu:latest
-```
+<Tabs>
+  <TabItem value="Holesky" label="Holesky">
+
+  ```bash
+  docker run -p 30303:30303 -p 8545:8545 -e BESU_RPC_HTTP_ENABLED=true -e BESU_NETWORK=holesky hyperledger/besu:latest
+  ```
+  </TabItem>
+
+  <TabItem value="Ephemery" label="Ephemery">
+  
+  ```bash
+  docker run -p 30303:30303 -p 8545:8545 -e BESU_RPC_HTTP_ENABLED=true -e BESU_NETWORK=ephemery hyperledger/besu:latest
+  ```
+  </TabItem>
+</Tabs>
 
 :::caution "Unsupported address type exception"
 

--- a/docs/private-networks/how-to/configure/bootnodes.md
+++ b/docs/private-networks/how-to/configure/bootnodes.md
@@ -24,7 +24,7 @@ To find peers, configure one or more bootnodes. To configure a specific set of p
 
 :::note Mainnet and public testnets
 
-For Mainnet and the Sepolia and Holesky testnets, Besu has an internal list of enode URLs and uses this list automatically when you specify the [`--network`](../../../public-networks/reference/cli/options.md#network) option.
+For Mainnet and the Sepolia, Ephemery and Holesky testnets, Besu has an internal list of enode URLs and uses this list automatically when you specify the [`--network`](../../../public-networks/reference/cli/options.md#network) option.
 
 :::
 

--- a/docs/private-networks/how-to/monitor/chainlens.md
+++ b/docs/private-networks/how-to/monitor/chainlens.md
@@ -72,7 +72,7 @@ The **Dashboard** page provides an aggregated view of network activities.
 ![`Chainlens_dashboard`](../../../assets/images/chainlens-dashboard.png)
 
 The **Network** page provides an overview of the network status and connected peers.
-This page is disabled by default, and is only visible if you set `DISPLAY_NETWOR_TAB=enabled` using
+This page is disabled by default, and is only visible if you set `DISPLAY_NETWORK_TAB=enabled` using
 the following command:
 
 ```bash

--- a/docs/public-networks/concepts/network-and-chain-id.md
+++ b/docs/public-networks/concepts/network-and-chain-id.md
@@ -42,6 +42,7 @@ Besu sets the chain ID (and by default the network ID) automatically, using eith
 | `dev`     | ETH   | 2018     | 2018       | Development |
 | `classic` | ETC   | 61       | 1          | Production  |
 | `mordor`  | ETC   | 63       | 7          | Test        |
+| `ephemery`| ETH   | [ChainId Updates](https://github.com/ephemery-testnet/ephemery-genesis/releases)    | [ChainId Updates](https://github.com/ephemery-testnet/ephemery-genesis/releases)      | Test        |
 
 :::info
 

--- a/docs/public-networks/concepts/network-and-chain-id.md
+++ b/docs/public-networks/concepts/network-and-chain-id.md
@@ -42,7 +42,7 @@ Besu sets the chain ID (and by default the network ID) automatically, using eith
 | `dev`     | ETH   | 2018     | 2018       | Development |
 | `classic` | ETC   | 61       | 1          | Production  |
 | `mordor`  | ETC   | 63       | 7          | Test        |
-| `ephemery`| ETH   | [ChainId Updates](https://github.com/ephemery-testnet/ephemery-genesis/releases)    | [ChainId Updates](https://github.com/ephemery-testnet/ephemery-genesis/releases)      | Test        |
+| `ephemery`| ETH   | [dynamic](https://github.com/ephemery-testnet/ephemery-genesis/releases)    | [dynamic](https://github.com/ephemery-testnet/ephemery-genesis/releases)      | Test        |
 
 :::info
 

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -108,7 +108,7 @@ You need Besu version 22.4.3 or later to use checkpoint sync.
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the
 genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](genesis-file.md).
 
-Ethereum Mainnet, Holesky and Ephemery testnet configurations already define default checkpoints, so you
+Ethereum Mainnet, Holesky, and Ephemery testnet configurations already define default checkpoints, so you
 don't have to add this yourself.
 
 For other networks, you can configure a checkpoint in the genesis file by specifying the block hash,

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -108,7 +108,7 @@ You need Besu version 22.4.3 or later to use checkpoint sync.
 Checkpoint sync behaves like [snap sync](#snap-synchronization), but instead of syncing from the
 genesis block, it syncs from a specific checkpoint block configured in the [Besu genesis file](genesis-file.md).
 
-Ethereum Mainnet and the Holesky testnet configurations already define default checkpoints, so you
+Ethereum Mainnet, Holesky and Ephemery testnet configurations already define default checkpoints, so you
 don't have to add this yourself.
 
 For other networks, you can configure a checkpoint in the genesis file by specifying the block hash,

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -58,7 +58,7 @@ If you can't get testnet ETH using the faucet, you can ask for help on the [EthS
 
 :::
 
-Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/) or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg).
+Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/), or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg).
 
 :::info
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Connect to a testnet
 
-Run Besu as an [execution client](../../concepts/node-clients.md#execution-clients) with any consensus client on the [Holesky](https://github.com/eth-clients/holesky) and [Sepolia](https://github.com/eth-clients/sepolia) testnets.
+Run Besu as an [execution client](../../concepts/node-clients.md#execution-clients) with any consensus client on the [Holesky](https://github.com/eth-clients/holesky), [Sepolia](https://github.com/eth-clients/sepolia) and [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) testnets.
 
 If you're using [Teku](https://docs.teku.consensys.net/en/latest/) as a consensus client, you can follow the [Besu and Teku testnet tutorial](../../tutorials/besu-teku-testnet.md).
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Connect to a testnet
 
-Run Besu as an [execution client](../../concepts/node-clients.md#execution-clients) with any consensus client on the [Holesky](https://github.com/eth-clients/holesky), [Sepolia](https://github.com/eth-clients/sepolia) and [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) testnets.
+Run Besu as an [execution client](../../concepts/node-clients.md#execution-clients) with any consensus client on the [Holesky](https://github.com/eth-clients/holesky), [Sepolia](https://github.com/eth-clients/sepolia), and [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) testnets.
 
 If you're using [Teku](https://docs.teku.consensys.net/en/latest/) as a consensus client, you can follow the [Besu and Teku testnet tutorial](../../tutorials/besu-teku-testnet.md).
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -21,6 +21,12 @@ Sepolia is a permissioned network and you can't run a validator client on it wit
 
 :::
 
+:::note
+
+Ephemery is a single network that rolls back to the genesis after a set period of time. Ephemery is focused on short term and heavy testing usecases. The purpose of this is also to avoid problems like insufficient testnet funds, inactive validators, state bloat, and similar issues faced by long-running testnets.
+
+:::
+
 ## Prerequisites
 
 - [Besu installed](../install/binary-distribution.md).
@@ -42,7 +48,7 @@ You will specify `jwtsecret.hex` when starting Besu and the consensus client. Th
 
 If you're running the consensus client as a beacon node only, skip to the [next step](#3-start-besu).
 
-If you're also running the consensus client as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky) and [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
+If you're also running the consensus client as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia) and [Ephemery faucets](https://ephemery-faucet.pk910.de/).
 
 :::note
 
@@ -50,7 +56,7 @@ If you can't get testnet ETH using the faucet, you can ask for help on the [EthS
 
 :::
 
-Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/) (or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg)).
+Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/) or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg).
 
 :::info
 
@@ -100,6 +106,23 @@ besu \
 
 </TabItem>
 
+  <TabItem value="Ephemery" label="Ephemery">
+
+  ```bash
+  besu \
+    --network=ephemery          \
+    --rpc-http-enabled=true     \
+    --rpc-http-host=0.0.0.0     \
+    --rpc-http-cors-origins="*" \
+    --rpc-ws-enabled=true       \
+    --rpc-ws-host=0.0.0.0       \
+    --host-allowlist="*"        \
+    --engine-host-allowlist="*" \
+    --engine-rpc-enabled        \
+    --engine-jwt-secret=<path to jwtsecret.hex>
+  ```
+
+  </TabItem>
 </Tabs>
 
 Specify the path to the `jwtsecret.hex` file generated in [step 1](#1-generate-the-shared-secret) using the [`--engine-jwt-secret`](../../reference/cli/options.md#engine-jwt-secret) option.
@@ -160,6 +183,6 @@ If you're running the consensus client as a beacon node only, you're all set. If
 
 ### 6. Stake ETH
 
-Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/).
+Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/) or [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
 
-You can check your validator status by searching your Ethereum address on the [Holesky Beacon Chain explorer](https://holesky.beaconcha.in/). It may take up to multiple days for your validator to be activated and start proposing blocks.
+You can check your validator status by searching your Ethereum address on the [Holesky Beacon Chain explorer](https://holesky.beaconcha.in/) or [Ephemery Beacon Chain explorer](https://beaconchain.ephemery.dev/). It may take up to multiple days for your validator to be activated and start proposing blocks.

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -23,7 +23,9 @@ Sepolia is a permissioned network and you can't run a validator client on it wit
 
 :::note
 
-Ephemery is a single network that rolls back to the genesis after a set period of time. Ephemery is focused on short term and heavy testing usecases. The purpose of this is also to avoid problems like insufficient testnet funds, inactive validators, state bloat faced by long-running testnets.
+Ephemery is a single network that resets to the genesis block after a set period. The network focuses on
+short-term, intensive testing use cases. This approach avoids issues like insufficient testnet funds, inactive
+validators, and state bloat that long-running testnets face.
 
 :::
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -23,7 +23,7 @@ Sepolia is a permissioned network and you can't run a validator client on it wit
 
 :::note
 
-Ephemery is a single network that rolls back to the genesis after a set period of time. Ephemery is focused on short term and heavy testing usecases. The purpose of this is also to avoid problems like insufficient testnet funds, inactive validators, state bloat, and similar issues faced by long-running testnets.
+Ephemery is a single network that rolls back to the genesis after a set period of time. Ephemery is focused on short term and heavy testing usecases. The purpose of this is also to avoid problems like insufficient testnet funds, inactive validators, state bloat faced by long-running testnets.
 
 :::
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -50,7 +50,7 @@ You will specify `jwtsecret.hex` when starting Besu and the consensus client. Th
 
 If you're running the consensus client as a beacon node only, skip to the [next step](#3-start-besu).
 
-If you're also running the consensus client as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia) and [Ephemery faucets](https://ephemery-faucet.pk910.de/).
+If you're also running the consensus client as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia), and [Ephemery faucets](https://ephemery-faucet.pk910.de/).
 
 :::note
 

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -24,7 +24,7 @@ To delete the local block data, delete the `database` directory in the `besu/bui
 
 ## Genesis configuration
 
-Besu specifies the genesis configuration, and sets the network ID and bootnodes when connecting to [Holesky](#run-a-node-on-holesky-testnet), [Sepolia](#run-a-node-on-sepolia-testnet),[Ephemery](#run-a-node-on-ephemery-testnet) and [Mainnet](#run-a-node-on-ethereum-mainnet).
+Besu specifies the genesis configuration, and sets the network ID and bootnodes when connecting to [Holesky](#run-a-node-on-holesky-testnet), [Sepolia](#run-a-node-on-sepolia-testnet), [Ephemery](#run-a-node-on-ephemery-testnet) and [Mainnet](#run-a-node-on-ethereum-mainnet).
 
 :::info
 

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -24,7 +24,7 @@ To delete the local block data, delete the `database` directory in the `besu/bui
 
 ## Genesis configuration
 
-Besu specifies the genesis configuration, and sets the network ID and bootnodes when connecting to [Holesky](#run-a-node-on-holesky-testnet), [Sepolia](#run-a-node-on-sepolia-testnet), and [Mainnet](#run-a-node-on-ethereum-mainnet).
+Besu specifies the genesis configuration, and sets the network ID and bootnodes when connecting to [Holesky](#run-a-node-on-holesky-testnet), [Sepolia](#run-a-node-on-sepolia-testnet),[Ephemery](#run-a-node-on-ephemery-testnet) and [Mainnet](#run-a-node-on-ethereum-mainnet).
 
 :::info
 
@@ -101,6 +101,18 @@ besu --network=sepolia --data-path=<path>/<sepoliadata-path>
 ```
 
 Where `<path>` and `<sepoliadata-path>` are the path and directory to save the Sepolia chain data to.
+
+See the [guide on connecting to a testnet](connect/testnet.md) for more information.
+
+## Run a node on Ephemery testnet
+
+To run a node on [Ephemery](https://github.com/ephemery-testnet/ephemery-resources?tab=readme-ov-file) specifying a data directory:
+
+```bash
+besu --network=ephemery --data-path=<path>/<ephemery-data-path>
+```
+
+Where `<path>` and `<ephemery-data-path>` are the path and directory to save the Ephemery chain data to.
 
 See the [guide on connecting to a testnet](connect/testnet.md) for more information.
 

--- a/docs/public-networks/index.md
+++ b/docs/public-networks/index.md
@@ -9,7 +9,7 @@ tags:
 
 # Besu for public networks
 
-Besu serves as an [execution client](concepts/node-clients.md#execution-clients) on public proof-of-stake Ethereum networks such as Ethereum Mainnet, Holesky, and Sepolia.
+Besu serves as an [execution client](concepts/node-clients.md#execution-clients) on public proof-of-stake Ethereum networks such as Ethereum Mainnet, Holesky, Ephemery and Sepolia.
 
 You can also run Besu using proof of work on [Ethereum Classic (ETC)](how-to/use-pow/mining.md).
 

--- a/docs/public-networks/index.md
+++ b/docs/public-networks/index.md
@@ -9,7 +9,7 @@ tags:
 
 # Besu for public networks
 
-Besu serves as an [execution client](concepts/node-clients.md#execution-clients) on public proof-of-stake Ethereum networks such as Ethereum Mainnet, Holesky, Ephemery and Sepolia.
+Besu serves as an [execution client](concepts/node-clients.md#execution-clients) on public proof-of-stake Ethereum networks such as Ethereum Mainnet, Holesky, Ephemery, and Sepolia.
 
 You can also run Besu using proof of work on [Ethereum Classic (ETC)](how-to/use-pow/mining.md).
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2688,6 +2688,7 @@ Possible values include the following:
 | `dev`     | ETH   | Development | [`FULL`](#sync-mode) | A PoW network            | Development network with low difficulty to enable local CPU mining             |
 | `classic` | ETC   | Production  | [`SNAP`](#sync-mode) | A PoW network            | The main [Ethereum Classic network](https://ethereumclassic.org)               |
 | `mordor ` | ETC   | Test        | [`SNAP`](#sync-mode) | A PoW network            | Testnet for [Ethereum Classic](https://github.com/eth-classic/mordor)          |
+| `ephemery` | ETH   | Test        | [`SNAP`](#sync-mode) | A PoS network            | Multi-client testnet [Ephemery](https://ephemery.dev) 
 
 :::tip
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2688,7 +2688,7 @@ Possible values include the following:
 | `dev`     | ETH   | Development | [`FULL`](#sync-mode) | A PoW network            | Development network with low difficulty to enable local CPU mining             |
 | `classic` | ETC   | Production  | [`SNAP`](#sync-mode) | A PoW network            | The main [Ethereum Classic network](https://ethereumclassic.org)               |
 | `mordor ` | ETC   | Test        | [`SNAP`](#sync-mode) | A PoW network            | Testnet for [Ethereum Classic](https://github.com/eth-classic/mordor)          |
-| `ephemery` | ETH   | Test        | [`SNAP`](#sync-mode) | A PoS network            | Multi-client testnet [Ephemery](https://ephemery.dev) 
+| `ephemery` | ETH   | Test        | [`SNAP`](#sync-mode) | A PoS network            | Multi-client testnet [Ephemery](https://ephemery.dev) |
 
 :::tip
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -1,7 +1,7 @@
 ---
 title: Run Besu and Teku on a testnet
 sidebar_position: 2
-description: Run Besu and Teku on Holesky or Sepolia testnet.
+description: Run Besu and Teku on Holesky, Ephemery or Sepolia testnet.
 tags:
   - public networks
 ---
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Run Besu and Teku on a testnet
 
-Run Besu as an [execution client](../concepts/node-clients.md#execution-clients) and [Teku](https://docs.teku.consensys.net/) as a [consensus client](../concepts/node-clients.md#consensus-clients) on the [Holesky](https://github.com/eth-clients/holesky) and [Sepolia](https://github.com/eth-clients/sepolia) Ethereum testnets.
+Run Besu as an [execution client](../concepts/node-clients.md#execution-clients) and [Teku](https://docs.teku.consensys.net/) as a [consensus client](../concepts/node-clients.md#consensus-clients) on the [Holesky](https://github.com/eth-clients/holesky), [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) and [Sepolia](https://github.com/eth-clients/sepolia) Ethereum testnets.
 
 :::note
 
@@ -41,7 +41,7 @@ You will specify `jwtsecret.hex` when starting Besu and Teku. This is a shared J
 
 If you're running Teku as a beacon node only, skip to the [next step](#4-start-besu).
 
-If you're also running Teku as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky) and [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
+If you're also running Teku as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Ephemery faucets](https://ephemery-faucet.pk910.de/) and [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
 
 :::note
 
@@ -49,7 +49,7 @@ If you can't get ETH using the faucet, you can ask for help on the [EthStaker Di
 
 :::
 
-Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/) (or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg)).
+Generate validator keys for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/)  (or [request to become validator on Sepolia](https://notes.ethereum.org/zvkfSmYnT0-uxwwEegbCqg)).
 
 :::info
 
@@ -97,6 +97,23 @@ besu \
 
 </TabItem>
 
+<TabItem value="Ephemery" label="Ephemery" default>
+
+```bash
+besu \
+  --network=ephemery           \
+  --rpc-http-enabled=true     \
+  --rpc-http-cors-origins="*" \
+  --rpc-ws-enabled=true       \
+  --p2p-host=<your public IP> \
+  --host-allowlist="*"        \
+  --engine-host-allowlist="*" \
+  --engine-rpc-enabled        \
+  --engine-jwt-secret=<path to jwtsecret.hex>
+```
+
+</TabItem>
+
 </Tabs>
 
 Specify the path to the `jwtsecret.hex` file generated in [step 2](#2-generate-the-shared-secret) using the [`--engine-jwt-secret`](../reference/cli/options.md#engine-jwt-secret) option.
@@ -133,6 +150,21 @@ teku \
 ```bash
 teku \
   --network=sepolia                            \
+  --ee-endpoint=http://localhost:8551          \
+  --ee-jwt-secret-file=<path to jwtsecret.hex> \
+  --metrics-enabled=true                       \
+  --rest-api-enabled=true                      \
+  --p2p-advertised-ip=<your public IP>         \  
+  --checkpoint-sync-url=<checkpoint sync URL>
+```
+
+</TabItem>
+
+<TabItem value="Ephemery" label="Ephemery" default>
+
+```bash
+teku \
+  --network=ephemery                            \
   --ee-endpoint=http://localhost:8551          \
   --ee-jwt-secret-file=<path to jwtsecret.hex> \
   --metrics-enabled=true                       \
@@ -249,9 +281,9 @@ If you're running Teku as a beacon node only, you're all set. If you're also run
 
 ## 7. Stake ETH
 
-Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/).
+Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/) or [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
 
-You can check your validator status by searching your Ethereum address on the [Holesky Beacon Chain explorer](https://holesky.beaconcha.in/). It may take up to multiple days for your validator to be activated and start proposing blocks.
+You can check your validator status by searching your Ethereum address on the [Holesky Beacon Chain explorer](https://holesky.beaconcha.in/) or [Ephemery Beacon Chain explorer](https://beaconchain.ephemery.dev/). It may take up to multiple days for your validator to be activated and start proposing blocks.
 
 <!--links-->
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 # Run Besu and Teku on a testnet
 
-Run Besu as an [execution client](../concepts/node-clients.md#execution-clients) and [Teku](https://docs.teku.consensys.net/) as a [consensus client](../concepts/node-clients.md#consensus-clients) on the [Holesky](https://github.com/eth-clients/holesky), [Ephemery](https://github.com/ephemery-testnet/ephemery-resources) and [Sepolia](https://github.com/eth-clients/sepolia) Ethereum testnets.
+Run Besu as an [execution client](../concepts/node-clients.md#execution-clients) and [Teku](https://docs.teku.consensys.net/) as a [consensus client](../concepts/node-clients.md#consensus-clients) on the [Holesky](https://github.com/eth-clients/holesky), [Ephemery](https://github.com/ephemery-testnet/ephemery-resources), and [Sepolia](https://github.com/eth-clients/sepolia) Ethereum testnets.
 
 :::note
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -41,7 +41,7 @@ You will specify `jwtsecret.hex` when starting Besu and Teku. This is a shared J
 
 If you're running Teku as a beacon node only, skip to the [next step](#4-start-besu).
 
-If you're also running Teku as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Ephemery faucets](https://ephemery-faucet.pk910.de/) and [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
+If you're also running Teku as a validator client, create a test Ethereum address (you can do this in [MetaMask](https://metamask.zendesk.com/hc/en-us/articles/360015289452-How-to-create-an-additional-account-in-your-wallet)). Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the list of [Holesky faucets](https://github.com/eth-clients/holesky), [Ephemery faucets](https://ephemery-faucet.pk910.de/), and [Sepolia faucets](https://github.com/eth-clients/sepolia#meta-data-sepolia).
 
 :::note
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -1,7 +1,7 @@
 ---
 title: Run Besu and Teku on a testnet
 sidebar_position: 2
-description: Run Besu and Teku on Holesky, Ephemery or Sepolia testnet.
+description: Run Besu and Teku on Holesky, Ephemery, or Sepolia testnet.
 tags:
   - public networks
 ---

--- a/src/components/HomepageCards/index.tsx
+++ b/src/components/HomepageCards/index.tsx
@@ -26,7 +26,7 @@ const CardList: CardItem[] = [
     // prettier-ignore
     description: (
       <>
-        Run Besu as an execution client on Ethereum Mainnet and Ethereum public testnets, such as Holesky and Sepolia.
+        Run Besu as an execution client on Ethereum Mainnet and Ethereum public testnets, such as Holesky, Ephemery and Sepolia.
       </>
     ),
     buttonName: "Get started",

--- a/src/components/HomepageCards/index.tsx
+++ b/src/components/HomepageCards/index.tsx
@@ -26,7 +26,7 @@ const CardList: CardItem[] = [
     // prettier-ignore
     description: (
       <>
-        Run Besu as an execution client on Ethereum Mainnet and Ethereum public testnets, such as Holesky, Ephemery and Sepolia.
+        Run Besu as an execution client on Ethereum Mainnet and Ethereum public testnets, such as Holesky, Ephemery, and Sepolia.
       </>
     ),
     buttonName: "Get started",


### PR DESCRIPTION
## Description
This PR add Ephemery commands to the following files:
- testnet.md
- run-docker-image.md
- bootnodes.md
- index.md
- network-and-chain-id.md
- node-sync.md
- start-node.md
- options.md
- besu-teku-testnet.md
- index.tsx


### Issue(s) fixed
 Fixes #1726

### Preview
https://besu-docs-git-fork-gconnect-add-documentatio-04d83e-hyperledger.vercel.app

