### PR TITLE
log4j: replace status (deprecated) with level

### DIFF
--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -36,7 +36,7 @@ You can provide your own logging configuration using the standard Log4j 2 config
 
 ```xml title="debug.xml"
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration level="INFO">
   <Properties>
     <Property name="root.log.level">INFO</Property>
   </Properties>
@@ -119,4 +119,3 @@ The [Quorum Developer Quickstart](https://github.com/ConsenSys/quorum-dev-quicks
 
 [default configuration]: https://github.com/hyperledger/besu/blob/750580dcca349d22d024cc14a8171b2fa74b505a/besu/src/main/resources/log4j2.xml
 [log rotation to restrict the size of the log files]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/besu/config/besu/log-config.xml
-[default configuration]: https://github.com/hyperledger/besu/blob/750580dcca349d22d024cc14a8171b2fa74b505a/besu/src/main/resources/log4j2.xml


### PR DESCRIPTION
## Description
 The attribute status has been deprecated in log4j since log4j version 2.24.0. Reference: https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-status

