### PR TITLE
Doc 1759

### DIFF
--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -143,12 +143,13 @@ Override an account with the following state values temporarily before making th
 to make ephemeral state changes, for the purposes of transaction simulation, without affecting the actual
 blockchain state.
 
-| Key         |   Type   | Value                                                                  |
-|-------------|:--------:|------------------------------------------------------------------------|
-| `balance`   | Quantity | Temporary account balance for the call execution.                      |
-| `nonce`     | Quantity | Temporary nonce value for the call execution.                          |
-| `code`      |  Binary  | Bytecode to inject into the account.                                   |
-| `stateDiff` | Quantity | `key:value` pairs to override individual slots in the account storage. |
+| Key                       |        Type         | Value                                                                  |
+|---------------------------|:-------------------:|------------------------------------------------------------------------|
+| `balance`                 |      Quantity       | Temporary account balance for the call execution.                      |
+| `nonce`                   |      Quantity       | Temporary nonce value for the call execution.                          |
+| `code`                    |       Binary        | Bytecode to inject into the account.                                   |
+| `movePrecompileToAddress` | Data, 20&nbsp;bytes | Address to move the precompile to.                                     |
+| `stateDiff`               |      Quantity       | `key:value` pairs to override individual slots in the account storage. |
 
 ## Structured log object
 

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -148,7 +148,7 @@ blockchain state.
 | `balance`                 | Quantity            | Temporary account balance for the call execution.                      |
 | `nonce`                   | Quantity            | Temporary nonce value for the call execution.                          |
 | `code`                    | Binary              | Bytecode to inject into the account.                                   |
-| `movePrecompileToAddress` | Data, 20&nbsp;bytes | Address to move the precompile to.                                     |
+| `movePrecompileToAddress` | Data, 20&nbsp;bytes | Address to which the precompile address should be moved.               |
 | `stateDiff`               | Quantity            | `key:value` pairs to override individual slots in the account storage. |
 
 ## Structured log object

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -145,11 +145,11 @@ blockchain state.
 
 | Key                       |        Type         | Value                                                                  |
 |---------------------------|:-------------------:|------------------------------------------------------------------------|
-| `balance`                 |      Quantity       | Temporary account balance for the call execution.                      |
-| `nonce`                   |      Quantity       | Temporary nonce value for the call execution.                          |
-| `code`                    |       Binary        | Bytecode to inject into the account.                                   |
+| `balance`                 | Quantity            | Temporary account balance for the call execution.                      |
+| `nonce`                   | Quantity            | Temporary nonce value for the call execution.                          |
+| `code`                    | Binary              | Bytecode to inject into the account.                                   |
 | `movePrecompileToAddress` | Data, 20&nbsp;bytes | Address to move the precompile to.                                     |
-| `stateDiff`               |      Quantity       | `key:value` pairs to override individual slots in the account storage. |
+| `stateDiff`               | Quantity            | `key:value` pairs to override individual slots in the account storage. |
 
 ## Structured log object
 


### PR DESCRIPTION
## Description
Add support for the `movePrecompileToAddress` override option.

- 

### Issue(s) fixed

Fixes #1759 

### Preview
https://besu-docs-git-fork-bgravenorst-doc-1759-hyperledger.vercel.app/public-networks/reference/api/objects#state-override-object
