### PR TITLE
docs: Improve documentation fix SECURITY.md FIXME

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,16 +7,15 @@ hear from you. We will take all security bugs seriously and if confirmed upon in
 patch it within a reasonable amount of time and release a public security bulletin discussing the
 impact and credit the discoverer.
 
-You can report a security bug in two ways. The easiest is to email a description of the flaw and
+You can report a security bug by emailing a description of the flaw and
 any related information (for example reproduction steps, version) to
-[Hyperledger security email address`](mailto:security@hyperledger.org).
-
-<!-- FIXME form doesn't have a "Security Level" field.
-The other way is to file a confidential security bug in our
-[JIRA bug tracking system](https://jira.hyperledger.org/projects/BESU/). Be sure to set the "Security Level" to
-"Security issue".
--->
+[Hyperledger security email address](mailto:security@hyperledger.org).
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in
 our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our
 [wiki](https://wiki.hyperledger.org).
+
+## Security Updates
+
+Security updates will be released according to our security response policy. To receive security
+update notifications, please watch the [Besu GitHub repository](https://github.com/hyperledger/besu/).


### PR DESCRIPTION
## Description

**SECURITY.md Update**:
   - Removed commented out FIXME note about the "Security Level" field
   - Streamlined security reporting instructions to focus on the email method
   - Added a "Security Updates" section to provide guidance on how to stay informed about security patches

### Issue(s) fixed

Fixes # FIXME
