### PR TITLE
Add instructions for utilising ERA1 files in full sync

### DIFF
--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -230,6 +230,9 @@ You can enable full sync using [`--sync-mode=FULL`](../reference/cli/options.md#
 Use full sync to run an [archive node](#archive-nodes).
 Full sync starts from the genesis block and reprocesses all transactions.
 
+You can optionally [download and sync pre-merge Ethereum history](../how-to/era1-file-full-sync.md)
+from ERA1 archive files instead of relying on peered nodes for the data.
+
 :::caution important
 Do not run an archive node with the [Bonsai Tries](data-storage-formats.md#bonsai-tries)
 data storage format.

--- a/docs/public-networks/how-to/era1-file-full-sync.md
+++ b/docs/public-networks/how-to/era1-file-full-sync.md
@@ -1,0 +1,26 @@
+---
+title: Utilize ERA1 files for Full sync
+sidebar_position: 9
+description: Utilize ERA1 files for Full sync
+tags:
+  - public networks
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Node operators using [Full sync](../concepts/node-sync.md#full-synchronization) can utilise ERA1 files as the source of pre-merge blocks in a pre-pipeline.
+
+## How to use the prepipeline
+
+The ERA1 import pre-pipeline can be activated and controlled with the following besu command options:
+
+```bash
+besu --era1-import-prepipeline-enabled --era1-data-uri=<filesystem path or http URI> --era1-import-prepipeline-concurrency=1
+```
+
+1. `--era1-import-prepipeline-enabled` activates the pre-pipeline
+2. `--era1-data-uri` specifies the location of the ERA1 files to be imported. Either a simple filesystem path (`/path/to/files/`), or a HTTP address (`https://mainnet.era1.nimbus.team`). If unspecified, this option will default to `https://mainnet.era1.nimbus.team`
+3. `--era1-import-prepipeline-concurrency` specifies the desired level of concurrency in the pre-pipeline. This option will default to 1. Due to a bottleneck in the block import process, this option should probably be left at 1 unless extremely slow download speeds are impacting the process.
+
+Immediately after the ERA1 import pre-pipeline, Besu will use [Full sync](../concepts/node-sync.md#full-synchronization) to complete the synchonization process.

--- a/docs/public-networks/how-to/era1-file-full-sync.md
+++ b/docs/public-networks/how-to/era1-file-full-sync.md
@@ -6,8 +6,8 @@ tags:
   - public networks
 ---
 
-When running [Full sync](../concepts/node-sync.md#full-synchronization), node operators can optionally
-import pre-merge block history from locally stored or remote ERA1 archive files. This method allows
+When running [full sync](../concepts/node-sync.md#full-synchronization), node operators can optionally
+import [pre-merge](https://ethereum.org/en/roadmap/merge/) block history from locally stored or remote ERA1 archive files. This method allows
 nodes to bootstrap pre-merge Ethereum data without relying on peer-to-peer downloads.
 
 ERA1 file import must be explicitly enabled by including the following command line options:
@@ -23,7 +23,7 @@ In the command:
     This option only applies in `FULL` sync mode.
 - [`--era1-data-uri`](../reference/cli/options.md#era1-data-uri) specifies the location of the ERA1
     files to be imported. Either a simple filesystem path (`/path/to/files/`), or an HTTP address
-    (`https://mainnet.era1.nimbus.team`). If unspecified, this option defaults to
+    (`https://mainnet.era1.nimbus.team`). The default is
     `https://mainnet.era1.nimbus.team`.
 - [`--era1-import-prepipeline-concurrency`](../reference/cli/options.md#era1-import-prepipeline-concurrency)
     sets the number of parallel processes used to import ERA1 files. The default is `1`.

--- a/docs/public-networks/how-to/era1-file-full-sync.md
+++ b/docs/public-networks/how-to/era1-file-full-sync.md
@@ -1,26 +1,33 @@
 ---
-title: Utilize ERA1 files for Full sync
+title: Import ERA1 files
 sidebar_position: 9
-description: Utilize ERA1 files for Full sync
+description: Import pre-merge Ethereum history from ERA1 archive files when using Full sync
 tags:
   - public networks
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+When running [Full sync](../concepts/node-sync.md#full-synchronization), node operators can optionally
+import pre-merge block history from locally stored or remote ERA1 archive files. This method allows
+nodes to bootstrap pre-merge Ethereum data without relying on peer-to-peer downloads.
 
-Node operators using [Full sync](../concepts/node-sync.md#full-synchronization) can utilise ERA1 files as the source of pre-merge blocks in a pre-pipeline.
-
-## How to use the prepipeline
-
-The ERA1 import pre-pipeline can be activated and controlled with the following besu command options:
+ERA1 file import must be explicitly enabled by including the following command line options:
 
 ```bash
-besu --era1-import-prepipeline-enabled --era1-data-uri=<filesystem path or http URI> --era1-import-prepipeline-concurrency=1
+besu --era1-import-prepipeline-enabled --era1-data-uri=<PATH-OR-URI> --era1-import-prepipeline-concurrency=1
 ```
 
-1. `--era1-import-prepipeline-enabled` activates the pre-pipeline
-2. `--era1-data-uri` specifies the location of the ERA1 files to be imported. Either a simple filesystem path (`/path/to/files/`), or a HTTP address (`https://mainnet.era1.nimbus.team`). If unspecified, this option will default to `https://mainnet.era1.nimbus.team`
-3. `--era1-import-prepipeline-concurrency` specifies the desired level of concurrency in the pre-pipeline. This option will default to 1. Due to a bottleneck in the block import process, this option should probably be left at 1 unless extremely slow download speeds are impacting the process.
+In the command:
 
-Immediately after the ERA1 import pre-pipeline, Besu will use [Full sync](../concepts/node-sync.md#full-synchronization) to complete the synchonization process.
+- [`--era1-import-prepipeline-enabled`](../reference/cli/options.md#era1-import-prepipeline-enabled)
+    enables importing pre-merge blocks from ERA1 archive files before full synchronization begins.
+    This option only applies in `FULL` sync mode.
+- [`--era1-data-uri`](../reference/cli/options.md#era1-data-uri) specifies the location of the ERA1
+    files to be imported. Either a simple filesystem path (`/path/to/files/`), or an HTTP address
+    (`https://mainnet.era1.nimbus.team`). If unspecified, this option defaults to
+    `https://mainnet.era1.nimbus.team`.
+- [`--era1-import-prepipeline-concurrency`](../reference/cli/options.md#era1-import-prepipeline-concurrency)
+    sets the number of parallel processes used to import ERA1 files. The default is `1`.
+    Increase only if you encounter slow file download speeds and your system can handle additional load.
+
+After all ERA1 files are imported, Besu automatically continues with full synchronization to complete
+syncing the rest of the chain.

--- a/docs/public-networks/how-to/pre-merge-history-expiry.md
+++ b/docs/public-networks/how-to/pre-merge-history-expiry.md
@@ -23,8 +23,6 @@ If you need to restore the full pre-merge history, you can revert to the former 
 all blocks from peers by setting
 [`--snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false`](../reference/cli/options.md#snapsync-synchronizer-pre-checkpoint-headers-only-enabled).
 
-Support for Era1 sync for archive nodes is currently in progress.
-
 :::
 
 Besu provides multiple options to prune the historical blockchain data:

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -1015,7 +1015,7 @@ era1-data-uri="https://mainnet.era1.nimbus.team/"
 
 </Tabs>
 
-The URI or local path to attempt to load ERA1 files from. For local files, a simple path may be used
+The URI or local path to attempt to [import ERA1 files](../../how-to/era1-file-full-sync.md) from. For local files, a simple path may be used
 (for example, `/home/user/era1`). The default is `https://mainnet.era1.nimbus.team/`.
 
 ### `era1-import-prepipeline-concurrency`
@@ -1056,11 +1056,11 @@ era1-import-prepipeline-concurrency=2
 
 </Tabs>
 
-Number of parallel processes used to import ERA1 archive files before full synchronization begins.
+Number of parallel processes used to [import ERA1 archive files](../../how-to/era1-file-full-sync.md) before full synchronization begins.
 Increasing this may improve performance when loading files from remote sources or on systems with
 high I/O capacity. The default is `1`.
 
-In most cases, `1` is recommended unless slow file downloads are a limiting factor.
+In most cases, we recommend using the default unless slow file downloads are a limiting factor.
 
 ### `era1-import-prepipeline-enabled`
 
@@ -1100,7 +1100,7 @@ era1-import-prepipeline-enabled=true
 
 </Tabs>
 
-Enables importing pre-merge blocks from ERA1 archive files before full sync begins. Files are loaded from the location specified by[`--era1-data-uri`](#era1-data-uri) (supports local paths and HTTP URLs).
+Enables [importing pre-merge blocks from ERA1 archive files](../../how-to/era1-file-full-sync.md) before full sync begins. Files are loaded from the location specified by[`--era1-data-uri`](#era1-data-uri) (supports local paths and HTTP URLs).
 
 This option only applies when [`--sync-mode=FULL`](#sync-mode); it has no effect in other sync modes. The default is `false`.
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -977,6 +977,135 @@ engine-rpc-port="8551"
 
 The listening port for the Engine API calls (`ENGINE`, `ETH`) for JSON-RPC over HTTP and WebSocket. The default is `8551`.
 
+### `era1-data-uri`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--era1-data-uri=<URI>
+```
+
+</TabItem>
+
+<TabItem value="Example" label="Example">
+
+```bash
+--era1-data-uri=https://mainnet.era1.nimbus.team/
+```
+
+</TabItem>
+
+<TabItem value="Environment variable" label="Environment variable">
+
+```bash
+BESU_ERA1_DATA_URI=https://mainnet.era1.nimbus.team/
+```
+
+</TabItem>
+
+<TabItem value="Configuration file" label="Configuration file">
+
+```bash
+era1-data-uri="https://mainnet.era1.nimbus.team/"
+```
+
+</TabItem>
+
+</Tabs>
+
+The URI or local path to attempt to load ERA1 files from. For local files, a simple path may be used
+(for example, `/home/user/era1`). The default is `https://mainnet.era1.nimbus.team/`.
+
+### `era1-import-prepipeline-concurrency`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--era1-import-prepipeline-concurrency=<INTEGER>
+```
+
+</TabItem>
+
+<TabItem value="Example" label="Example">
+
+```bash
+--era1-import-prepipeline-concurrency=2
+```
+
+</TabItem>
+
+<TabItem value="Environment variable" label="Environment variable">
+
+```bash
+BESU_ERA1_IMPORT_PREPIPELINE_CONCURRENCY=2
+```
+
+</TabItem>
+
+<TabItem value="Configuration file" label="Configuration file">
+
+```bash
+era1-import-prepipeline-concurrency=2
+```
+
+</TabItem>
+
+</Tabs>
+
+Number of parallel processes used to import ERA1 archive files before full synchronization begins.
+Increasing this may improve performance when loading files from remote sources or on systems with
+high I/O capacity. The default is `1`.
+
+In most cases, `1` is recommended unless slow file downloads are a limiting factor.
+
+### `era1-import-prepipeline-enabled`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--era1-import-prepipeline-enabled[=<Boolean>]
+```
+
+</TabItem>
+
+<TabItem value="Example" label="Example">
+
+```bash
+--era1-import-prepipeline-enabled=true
+```
+
+</TabItem>
+
+<TabItem value="Environment variable" label="Environment variable">
+
+```bash
+BESU_ERA1_IMPORT_PREPIPELINE_ENABLED=true
+```
+
+</TabItem>
+
+<TabItem value="Configuration file" label="Configuration file">
+
+```bash
+era1-import-prepipeline-enabled=true
+```
+
+</TabItem>
+
+</Tabs>
+
+Enables importing pre-merge blocks from ERA1 archive files before full sync begins. Files are loaded from the location specified by[`--era1-data-uri`](#era1-data-uri) (supports local paths and HTTP URLs).
+
+This option only applies when [`--sync-mode=FULL`](#sync-mode); it has no effect in other sync modes. The default is `false`.
+
+Use this to accelerate syncing from genesis or to restore full historical data without relying on peer-to-peer downloads.
+
 ### `estimate-gas-tolerance-ratio`
 
 <Tabs>


### PR DESCRIPTION
## Description
Adds a How To page to instruct in how Besu can use ERA1 files in a pre-pipeline on full sync

### Issue(s) fixed
https://github.com/hyperledger/besu/issues/8491

### Preview
- https://besu-docs-git-fork-matilda-clerke-add-era1-f-5f6092-hyperledger.vercel.app/public-networks/reference/cli/options#era1-data-uri
- https://besu-docs-git-fork-matilda-clerke-add-era1-f-5f6092-hyperledger.vercel.app/public-networks/how-to/era1-file-full-sync