### PR TITLE
Update the `--bootnodes` option to accept a file location

### DIFF
--- a/docs/private-networks/how-to/configure/bootnodes.md
+++ b/docs/private-networks/how-to/configure/bootnodes.md
@@ -33,15 +33,32 @@ For Mainnet and the Sepolia, Ephemery and Holesky testnets, Besu has an internal
 
 ## Specify a bootnode
 
-To start a node, specify a bootnode [enode](../../../public-networks/concepts/node-keys.md) for P2P discovery, using the [`--bootnodes`](../../../public-networks/reference/cli/options.md#bootnodes) option.
+To start a node, specify a bootnode [enode](../../../public-networks/concepts/node-keys.md) for P2P
+discovery, using the [`--bootnodes`](../../../public-networks/reference/cli/options.md#bootnodes) option.
 
 ```bash
 besu --genesis-file=privateNetworkGenesis.json --data-path=nodeDataPath --bootnodes=enode://c35c3ec90a8a51fd5703594c6303382f3ae6b2ecb99bab2c04b3794f2bc3fc2631dabb0c08af795787a6c004d8f532230ae6e9925cbbefb0b28b79295d615f@127.0.0.1:30303
 ```
 
-The default host and port advertised to other peers for P2P discovery is `127.0.0.1:30303`. To specify a different host or port, use the [`--p2p-host`](../../../public-networks/reference/cli/options.md#p2p-host) and [`--p2p-port`](../../../public-networks/reference/cli/options.md#p2p-port) options.
+The `--bootnodes` option also accepts files or URLs:
+- A local file path: `/path/to/bootnodes.txt`
+- A file URI: `file:///path/to/bootnodes.txt`
+- An HTTP(S) URL: `https://example.com/bootnodes.txt`
 
-By default, peer discovery listens on all available network interfaces. If the device Besu is running on must bind to a specific network interface, specify the interface using the [`--p2p-interface`](../../../public-networks/reference/cli/options.md#p2p-interface) option.
+You can mix sources, comma-separated, together with direct enode URLs:
+
+```bash
+besu --bootnodes=/etc/besu/bootnodes.txt,https://example.com/enodes.txt,enode://c35c3...d615f@1.2.3.4:30303
+```
+
+The default host and port advertised to other peers for P2P discovery is `127.0.0.1:30303`.
+To specify a different host or port, use the
+[`--p2p-host`](../../../public-networks/reference/cli/options.md#p2p-host) and
+[`--p2p-port`](../../../public-networks/reference/cli/options.md#p2p-port) options.
+
+By default, peer discovery listens on all available network interfaces. If the device Besu is running
+on must bind to a specific network interface, specify the interface using the
+[`--p2p-interface`](../../../public-networks/reference/cli/options.md#p2p-interface) option.
 
 ## Configure bootnodes in a production network
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -462,7 +462,7 @@ The default is `30000`.
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---bootnodes[=<enode://id@host:port>[,<enode://id@host:port>...]...]
+--bootnodes[=source>[,<source>...]...]
 ```
 
 </TabItem>
@@ -493,11 +493,19 @@ bootnodes=["enode://c35c3...d615f@1.2.3.4:30303","enode://f42c13...fc456@1.2.3.5
 
 </Tabs>
 
-A list of comma-separated [enode URLs](../../concepts/node-keys.md#enode-url) for [P2P discovery bootstrap](../../../private-networks/how-to/configure/bootnodes.md).
+A list of comma-separated sources for [P2P discovery bootstrap](../../../private-networks/how-to/configure/bootnodes.md),
+where each source can be:
 
+- A direct [enode URL](../../concepts/node-keys.md#enode-url): `enode://<id>@<host>:<port>`
+- A local file path: `/path/to/bootnodes.txt`
+- A file URI: `file:///path/to/bootnodes.txt`
+- An HTTP(S) URL: `https://example.com/bootnodes.txt`
+
+Each file or URL must contain one enode URL per line. Blank lines and lines starting with `#` are ignored.
 When connecting to Mainnet or public testnets, the default is a predefined list of enode URLs.
 
-In private networks defined using [`--genesis-file`](#genesis-file) or when using [`--network=dev`](#network), the default is an empty list of bootnodes.
+In private networks defined using [`--genesis-file`](#genesis-file) or when using
+[`--network=dev`](#network), the default is an empty list of bootnodes.
 
 ### `cache-last-blocks`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -462,7 +462,7 @@ The default is `30000`.
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---bootnodes[=source>[,<source>...]...]
+--bootnodes[=<source>[,<source>...]...]
 ```
 
 </TabItem>
@@ -494,7 +494,7 @@ bootnodes=["enode://c35c3...d615f@1.2.3.4:30303","enode://f42c13...fc456@1.2.3.5
 </Tabs>
 
 A list of comma-separated sources for [P2P discovery bootstrap](../../../private-networks/how-to/configure/bootnodes.md),
-where each source can be:
+where each source can be one of the following:
 
 - A direct [enode URL](../../concepts/node-keys.md#enode-url): `enode://<id>@<host>:<port>`
 - A local file path: `/path/to/bootnodes.txt`


### PR DESCRIPTION
## Description
The `--bootnodes` option now accepts a file.

### Issue(s) fixed
Fixes: #1843 

### Preview
- https://besu-docs-git-fork-bgravenorst-doc-1843-hyperledger.vercel.app/public-networks/reference/cli/options#bootnodes
- https://besu-docs-git-fork-bgravenorst-doc-1843-hyperledger.vercel.app/private-networks/how-to/configure/bootnodes#specify-a-bootnode 
