### PR TITLE
rename linea named network to linea_mainnet

### DIFF
--- a/docs/public-networks/concepts/network-and-chain-id.md
+++ b/docs/public-networks/concepts/network-and-chain-id.md
@@ -42,7 +42,7 @@ Besu sets the chain ID (and by default the network ID) automatically, using eith
 | `dev`     | ETH   | 2018     | 2018       | Development |
 | `ephemery`| ETH   | [dynamic](https://github.com/ephemery-testnet/ephemery-genesis/releases)    | [dynamic](https://github.com/ephemery-testnet/ephemery-genesis/releases)      | Test  |
 | `lukso`   | Lukso | 4201        | 4201    | Production  |
-| `linea`   | Linea | 59144       | 59144   | Production  |
+| `linea_mainnet`   | Linea | 59144       | 59144   | Production  |
 | `linea_sepolia`| Linea |59141   | 59141   | Test        |
 
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -3009,7 +3009,7 @@ Possible values include the following:
 | `sepolia`  | ETH   | Test        | [`SNAP`](#sync-mode) | PoS network       | Multi-client Ethereum testnet [Sepolia](https://sepolia.dev)                            |
 | `dev`      | ETH   | Development | [`FULL`](#sync-mode) | PoW network       | Development network with low difficulty to enable local CPU mining             |
 | `ephemery` | ETH   | Test        | [`SNAP`](#sync-mode) | PoS network       | Multi-client Ethereum testnet [Ephemery](https://ephemery.dev)  
-| `linea`  | Linea   | Production        | [`SNAP`](#sync-mode) | Sequencer-based (zkEVM rollup)       | The main [Linea network](https://docs.linea.build/get-started/build/network-info)                            |
+| `linea_mainnet`  | Linea   | Production        | [`SNAP`](#sync-mode) | Sequencer-based (zkEVM rollup)       | The main [Linea network](https://docs.linea.build/get-started/build/network-info)                            |
 | `linea_sepolia`  | Linea   | Test        | [`SNAP`](#sync-mode) | Sequencer-based (zkEVM rollup)      | Linea [Sepolia testnet](https://docs.linea.build/get-started/build/network-info/)                            |
 | `lukso`    | Lukso  | Production  | [`SNAP`](#sync-mode) | PoS network       | Network for the [Lukso chain](https://lukso.network/)                          |
 

--- a/docs/public-networks/reference/evm-tool.md
+++ b/docs/public-networks/reference/evm-tool.md
@@ -329,7 +329,7 @@ The [Besu genesis file](genesis-items.md) to use when evaluating the EVM. Most u
 <TabItem value="Syntax" label="Syntax" default>
 
 ```bash
---chain=<mainnet|sepolia|dev|hoodi|linea|linea_sepolia>
+--chain=<mainnet|sepolia|dev|hoodi|linea_mainnet|linea_sepolia>
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description
the name has changed to linea_mainnet
- 

### Issue(s) fixed

fixes #1879 

- 
