### PR TITLE
Update parallel tx execution throughput metrics

### DIFF
--- a/docs/public-networks/concepts/parallel-transaction-execution.md
+++ b/docs/public-networks/concepts/parallel-transaction-execution.md
@@ -161,13 +161,20 @@ GiB memory), with Teku and Nimbus as consensus layer (CL) clients:
   Besu, meaning less context switching and fewer cache misses.
 
 - **Execution throughput** - Benchmarking against mainnet big blocks shows a significant increase in
-  execution throughput (measured in megagas per second, Mgas/s) compared to sequential processing:
-  - Minimum: 194.55 Mgas/s
-  - Maximum: 445.99 Mgas/s
-  - Average: 348.17 Mgas/s
-  - 50th percentile: 352.57 Mgas/s
-  - 95th percentile: 404.93 Mgas/s
-  - 99th percentile: 418.13 Mgas/s
+  execution throughput (measured in megagas per second, Mgas/s) compared to sequential processing.
+  These results were collected on the following hardware:
+  - CPU: AMD EPYC 4344P, 8 cores/16 threads, 3.8 GHz base / 5.3 GHz boost
+  - RAM: 64 GB DDR5 5200 MHz
+  - Storage: 2x 960 GB NVMe SSD
+
+  | Metric | Throughput |
+  |--------|-----------|
+  | Minimum | 194.55 Mgas/s |
+  | Maximum | 445.99 Mgas/s |
+  | Average | 348.17 Mgas/s |
+  | 50th percentile | 352.57 Mgas/s |
+  | 95th percentile | 404.93 Mgas/s |
+  | 99th percentile | 418.13 Mgas/s |
 
 - **Parallel transactions** - Parallel transaction execution introduces two new metrics, which
   indicate that approximately 40% of transactions are parallelized using this feature:

--- a/docs/public-networks/concepts/parallel-transaction-execution.md
+++ b/docs/public-networks/concepts/parallel-transaction-execution.md
@@ -160,8 +160,14 @@ GiB memory), with Teku and Nimbus as consensus layer (CL) clients:
   Besu running with Nimbus has better performance than with Teku because Nimbus has less overhead on
   Besu, meaning less context switching and fewer cache misses.
 
-- **Execution throughput** - Execution throughput increases, with an average of 96 Mgas/s and peaks
-  of up to 250 Mgas/s.
+- **Execution throughput** - Benchmarking against mainnet big blocks shows a significant increase in
+  execution throughput (measured in megagas per second, Mgas/s) compared to sequential processing:
+  - Minimum: 194.55 Mgas/s
+  - Maximum: 445.99 Mgas/s
+  - Average: 348.17 Mgas/s
+  - 50th percentile: 352.57 Mgas/s
+  - 95th percentile: 404.93 Mgas/s
+  - 99th percentile: 418.13 Mgas/s
 
 - **Parallel transactions** - Parallel transaction execution introduces two new metrics, which
   indicate that approximately 40% of transactions are parallelized using this feature:

--- a/docs/public-networks/concepts/parallel-transaction-execution.md
+++ b/docs/public-networks/concepts/parallel-transaction-execution.md
@@ -163,9 +163,12 @@ GiB memory), with Teku and Nimbus as consensus layer (CL) clients:
 - **Execution throughput** - Benchmarking against mainnet big blocks shows a significant increase in
   execution throughput (measured in megagas per second, Mgas/s) compared to sequential processing.
   These results were collected on the following hardware:
+
   - CPU: AMD EPYC 4344P, 8 cores/16 threads, 3.8 GHz base / 5.3 GHz boost
   - RAM: 64 GB DDR5 5200 MHz
   - Storage: 2x 960 GB NVMe SSD
+
+  The following table shows the throughput results:
 
   | Metric | Throughput |
   |--------|-----------|


### PR DESCRIPTION
## Description

Updates the execution throughput numbers in the [parallel transaction execution](https://besu.hyperledger.org/public-networks/concepts/parallel-transaction-execution#metrics) concept page with more recent benchmark results from mainnet big block testing.

Replaces the outdated figures (avg 96 Mgas/s, peaks up to 250 Mgas/s) with the latest results:

- Minimum: 194.55 Mgas/s
- Maximum: 445.99 Mgas/s
- Average: 348.17 Mgas/s
- 50th percentile: 352.57 Mgas/s
- 95th percentile: 404.93 Mgas/s
- 99th percentile: 418.13 Mgas/s

Also adds an inline definition of Mgas/s (megagas per second) on first use for clarity.

### Issue(s) fixed

Fixes #1907
