### PR TITLE
Improve navigation between public and private networks

### DIFF
--- a/docs/private-networks/concepts/index.md
+++ b/docs/private-networks/concepts/index.md
@@ -2,8 +2,6 @@
 title: Concepts
 description: private networks concepts overview
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 # Concepts

--- a/docs/private-networks/concepts/node-sync-private.md
+++ b/docs/private-networks/concepts/node-sync-private.md
@@ -2,8 +2,6 @@
 sidebar_label: Node synchronization
 sidebar_position: 4
 description: Learn about node synchronization for private networks.
-tags:
-  - private networks
 ---
 
 # Node synchronization for private networks

--- a/docs/private-networks/concepts/permissioning/index.md
+++ b/docs/private-networks/concepts/permissioning/index.md
@@ -2,8 +2,6 @@
 title: Permissioning
 sidebar_position: 1
 description: Besu permissioning feature
-tags:
-  - private networks
 ---
 
 # Permissioning

--- a/docs/private-networks/concepts/permissioning/plugin.md
+++ b/docs/private-networks/concepts/permissioning/plugin.md
@@ -2,8 +2,6 @@
 title: Permissioning plugin
 description: Plugin based permissioning
 sidebar_position: 2
-tags:
-  - private networks
 ---
 
 # Permissioning plugin

--- a/docs/private-networks/concepts/poa.md
+++ b/docs/private-networks/concepts/poa.md
@@ -2,8 +2,6 @@
 title: Proof of authority consensus
 sidebar_position: 1
 description: Besu proof of authority consensus protocols comparison
-tags:
-  - private networks
 ---
 
 # Proof of authority consensus

--- a/docs/private-networks/get-started/install/binary-distribution.md
+++ b/docs/private-networks/get-started/install/binary-distribution.md
@@ -2,8 +2,6 @@
 title: Install binary distribution
 description: Install or upgrade Besu from binary distribution
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 # Install binary distribution

--- a/docs/private-networks/get-started/install/index.md
+++ b/docs/private-networks/get-started/install/index.md
@@ -2,8 +2,6 @@
 title: Installation options
 description: Options for getting started with Besu
 sidebar_position: 1
-tags:
-  - private networks
 ---
 
 # Installation options

--- a/docs/private-networks/get-started/install/run-docker-image.md
+++ b/docs/private-networks/get-started/install/run-docker-image.md
@@ -2,8 +2,6 @@
 title: Run Besu from Docker image
 description: Run Besu using the official docker image
 sidebar_position: 2
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/get-started/start-node.md
+++ b/docs/private-networks/get-started/start-node.md
@@ -2,8 +2,6 @@
 title: Start Besu
 description: Start Besu on a private Ethereum network.
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 # Start Besu

--- a/docs/private-networks/get-started/system-requirements.md
+++ b/docs/private-networks/get-started/system-requirements.md
@@ -2,8 +2,6 @@
 title: System requirements
 description: Ensure you meet the system requirements to sync and run Besu.
 sidebar_position: 1
-tags:
-  - private networks
 ---
 
 # System requirements

--- a/docs/private-networks/how-to/backup.md
+++ b/docs/private-networks/how-to/backup.md
@@ -2,8 +2,6 @@
 title: Backup and restore
 description: Backing up and restoring Besu
 sidebar_position: 7
-tags:
-  - private networks
 ---
 
 # Backup and restore Besu

--- a/docs/private-networks/how-to/configure/bootnodes.md
+++ b/docs/private-networks/how-to/configure/bootnodes.md
@@ -2,8 +2,6 @@
 title: Bootnodes
 description: Configuring bootnodes
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 # Configure bootnodes

--- a/docs/private-networks/how-to/configure/consensus/add-validators-without-voting.md
+++ b/docs/private-networks/how-to/configure/consensus/add-validators-without-voting.md
@@ -2,8 +2,6 @@
 title: Add and remove validators without voting
 description: How to add or remove validators without voting
 sidebar_position: 5
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/configure/consensus/ibft.md
+++ b/docs/private-networks/how-to/configure/consensus/ibft.md
@@ -2,8 +2,6 @@
 title: IBFT 2.0
 description: Besu IBFT 2.0 proof of authority (PoA) consensus protocol implementation
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/configure/consensus/index.md
+++ b/docs/private-networks/how-to/configure/consensus/index.md
@@ -2,8 +2,6 @@
 title: Consensus protocols
 description: Besu consensus protocols
 sidebar_position: 1
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/configure/consensus/qbft.md
+++ b/docs/private-networks/how-to/configure/consensus/qbft.md
@@ -2,8 +2,6 @@
 title: QBFT
 description: Besu QBFT proof of authority (PoA) consensus protocol implementation
 sidebar_position: 2
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/configure/contracts.md
+++ b/docs/private-networks/how-to/configure/contracts.md
@@ -2,8 +2,6 @@
 title: Pre-deploy a contract
 description: Pre-deploying contracts in the genesis file
 sidebar_position: 5
-tags:
-  - private networks
 ---
 
 # Pre-deploy contracts in the genesis file

--- a/docs/private-networks/how-to/configure/curves.md
+++ b/docs/private-networks/how-to/configure/curves.md
@@ -2,8 +2,6 @@
 title: Alternative elliptic curves
 description: Using alternative elliptic curves in Besu
 sidebar_position: 8
-tags:
-  - private networks
 ---
 
 # Configure alternative elliptic curves

--- a/docs/private-networks/how-to/configure/free-gas.md
+++ b/docs/private-networks/how-to/configure/free-gas.md
@@ -2,8 +2,6 @@
 title: Free gas network
 description: Configuring free gas networks
 sidebar_position: 2
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/configure/tls.md
+++ b/docs/private-networks/how-to/configure/tls.md
@@ -2,8 +2,6 @@
 title: Client and server TLS
 sidebar_position: 6
 sidebar_label: TLS
-tags:
-  - private networks
 ---
 
 # Configure client TLS

--- a/docs/private-networks/how-to/configure/validators.md
+++ b/docs/private-networks/how-to/configure/validators.md
@@ -2,8 +2,6 @@
 title: Validators
 description: Configuring validators in production networks
 sidebar_position: 4
-tags:
-  - private networks
 ---
 
 # Configure validators in a production network

--- a/docs/private-networks/how-to/deploy/ansible.md
+++ b/docs/private-networks/how-to/deploy/ansible.md
@@ -2,8 +2,6 @@
 sidebar_position: 2
 title: Use Ansible
 description: Deploying Besu with Ansible role on Galaxy
-tags:
-  - private networks
 ---
 
 # Deploy Besu with Ansible

--- a/docs/private-networks/how-to/deploy/cloud.md
+++ b/docs/private-networks/how-to/deploy/cloud.md
@@ -2,8 +2,6 @@
 title: Deploy to the cloud
 sidebar_position: 1
 description: Deploying Besu to the cloud
-tags:
-  - private networks
 ---
 
 # Deploy Besu to the cloud

--- a/docs/private-networks/how-to/deploy/ethstats.md
+++ b/docs/private-networks/how-to/deploy/ethstats.md
@@ -2,8 +2,6 @@
 sidebar_position: 4
 title: Use Ethstats network monitor
 description: Ethstats network monitor
-tags:
-  - private networks
 ---
 
 # Connect to Ethstats network monitor

--- a/docs/private-networks/how-to/deploy/kubernetes.md
+++ b/docs/private-networks/how-to/deploy/kubernetes.md
@@ -2,8 +2,6 @@
 sidebar_position: 3
 title: Use Kubernetes
 description: Deploying Besu with Kubernetes
-tags:
-  - private networks
 ---
 
 # Deploy Besu with Kubernetes

--- a/docs/private-networks/how-to/index.md
+++ b/docs/private-networks/how-to/index.md
@@ -1,7 +1,5 @@
 ---
 description: Private networks how to overview
-tags:
-  - private networks
 ---
 
 # How to

--- a/docs/private-networks/how-to/monitor/chainlens.md
+++ b/docs/private-networks/how-to/monitor/chainlens.md
@@ -2,8 +2,6 @@
 title: Use Chainlens Explorer
 sidebar_position: 7
 description: Use Chainlens Explorer on a Besu network
-tags:
-  - private networks
 ---
 
 # Use Chainlens Blockchain Explorer

--- a/docs/private-networks/how-to/monitor/elastic-stack.md
+++ b/docs/private-networks/how-to/monitor/elastic-stack.md
@@ -2,8 +2,6 @@
 title: Use Elastic Stack
 sidebar_position: 3
 description: Using Elastic Stack (ELK) with Besu
-tags:
-  - private networks
 ---
 
 # Use Elastic Stack

--- a/docs/private-networks/how-to/monitor/index.md
+++ b/docs/private-networks/how-to/monitor/index.md
@@ -1,7 +1,5 @@
 ---
 description: Monitoring using metrics and logging
-tags:
-  - private networks
 ---
 
 # Monitoring

--- a/docs/private-networks/how-to/monitor/loki.md
+++ b/docs/private-networks/how-to/monitor/loki.md
@@ -2,8 +2,6 @@
 title: Use Grafana Loki
 sidebar_position: 2
 description: Using Grafana Loki log management platform with Besu
-tags:
-  - private networks
 ---
 
 # Grafana Loki

--- a/docs/private-networks/how-to/monitor/opentelemetry.md
+++ b/docs/private-networks/how-to/monitor/opentelemetry.md
@@ -2,8 +2,6 @@
 title: Use OpenTelemetry
 sidebar_position: 6
 description: Collect Besu information with the OpenTelemetry Collector
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/how-to/monitor/splunk.md
+++ b/docs/private-networks/how-to/monitor/splunk.md
@@ -3,8 +3,6 @@ title: Use Splunk
 sidebar_position: 5
 toc_max_heading_level: 2
 description: Send Besu logs to Splunk
-tags:
-  - private networks
 ---
 
 # Use Splunk

--- a/docs/private-networks/how-to/send-transactions/index.md
+++ b/docs/private-networks/how-to/send-transactions/index.md
@@ -1,8 +1,6 @@
 ---
 title: Create and send transactions
 description: private networks send transactions overview
-tags:
-  - private networks
 ---
 
 # Create and send transactions

--- a/docs/private-networks/how-to/send-transactions/revert-reason.md
+++ b/docs/private-networks/how-to/send-transactions/revert-reason.md
@@ -2,8 +2,6 @@
 title: Include revert reason
 description: Including revert reason in transactions with Besu
 sidebar_position: 3
-tags:
-  - private networks
 ---
 
 # Revert reason

--- a/docs/private-networks/how-to/upgrade.md
+++ b/docs/private-networks/how-to/upgrade.md
@@ -2,8 +2,6 @@
 title: Upgrade
 description: Upgrading protocol versions
 sidebar_position: 8
-tags:
-  - private networks
 ---
 
 # Network and protocol upgrades

--- a/docs/private-networks/how-to/use-local-permissioning.md
+++ b/docs/private-networks/how-to/use-local-permissioning.md
@@ -2,8 +2,6 @@
 title: Use local permissioning
 sidebar_position: 5
 description: Besu local permissioning
-tags:
-  - private networks
 ---
 
 # Use local permissioning

--- a/docs/private-networks/index.md
+++ b/docs/private-networks/index.md
@@ -4,8 +4,6 @@ sidebar_position: 1
 sidebar_label: Introduction
 id: index
 description: Private networks overview
-tags:
-  - private networks
 ---
 
 # Besu for private (permissioned) networks

--- a/docs/private-networks/reference/accounts-for-testing.md
+++ b/docs/private-networks/reference/accounts-for-testing.md
@@ -2,8 +2,6 @@
 title: Accounts for testing
 sidebar_position: 3
 description: Ethereum accounts used for Besu testing only on private networks
-tags:
-  - private networks
 ---
 
 import TestAccounts from '../../global/test_accounts.md';

--- a/docs/private-networks/reference/api.md
+++ b/docs/private-networks/reference/api.md
@@ -3,8 +3,6 @@ description: Besu private network JSON-RPC API methods reference
 toc_max_heading_level: 3
 sidebar_position: 2
 sidebar_label: Besu API
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/reference/cli/options.md
+++ b/docs/private-networks/reference/cli/options.md
@@ -2,8 +2,6 @@
 title: Private network options
 sidebar_position: 1
 description: Besu private networks CLI reference
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/reference/cli/subcommands.md
+++ b/docs/private-networks/reference/cli/subcommands.md
@@ -2,8 +2,6 @@
 title: Private network subcommands
 sidebar_position: 2
 description: Besu command line interface subcommands
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/reference/index.md
+++ b/docs/private-networks/reference/index.md
@@ -1,7 +1,5 @@
 ---
 description: private networks reference overview
-tags:
-  - private networks
 ---
 
 # Reference

--- a/docs/private-networks/tutorials/azure.md
+++ b/docs/private-networks/tutorials/azure.md
@@ -2,8 +2,6 @@
 title: Deploy using Microsoft Azure
 sidebar_position: 10
 description: Deploy a private IBFT 2.0 network using Microsoft Azure.
-tags:
-  - private networks
 ---
 
 # Deploy private network example on Azure

--- a/docs/private-networks/tutorials/contracts/index.md
+++ b/docs/private-networks/tutorials/contracts/index.md
@@ -2,8 +2,6 @@
 title: Deploy a smart contract
 sidebar_position: 1
 description: deploying smart contracts
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/contracts/interact.md
+++ b/docs/private-networks/tutorials/contracts/interact.md
@@ -2,8 +2,6 @@
 title: Interact with a deployed contract
 sidebar_position: 2
 description: calling smart contracts functions
-tags:
-  - private networks
 ---
 
 # Interact with deployed smart contracts

--- a/docs/private-networks/tutorials/contracts/transfer-funds.md
+++ b/docs/private-networks/tutorials/contracts/transfer-funds.md
@@ -2,8 +2,6 @@
 title: Transfer account funds
 sidebar_position: 1
 description: funds transfer transactions
-tags:
-  - private networks
 ---
 
 # Transfer funds between accounts in a transaction

--- a/docs/private-networks/tutorials/ethash.md
+++ b/docs/private-networks/tutorials/ethash.md
@@ -2,8 +2,6 @@
 title: (Deprecated) Create an Ethash network
 sidebar_position: 5
 description: Create a private network using the (deprecated) Ethash consensus protocol.
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/ibft/index.md
+++ b/docs/private-networks/tutorials/ibft/index.md
@@ -1,7 +1,5 @@
 ---
 description: Besu private network using the IBFT 2.0 (Proof of Authority) consensus protocol
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/ibft/validators.md
+++ b/docs/private-networks/tutorials/ibft/validators.md
@@ -2,8 +2,6 @@
 title: Add and removing IBFT 2.0 validators
 sidebar_position: 1
 description: Adding and removing IBFT 2.0 validators
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/kubernetes/charts.md
+++ b/docs/private-networks/tutorials/kubernetes/charts.md
@@ -2,8 +2,6 @@
 title: Deploy charts
 sidebar_position: 3
 description: Deploying Besu Helm Charts for a Kubernetes cluster
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/kubernetes/cluster.md
+++ b/docs/private-networks/tutorials/kubernetes/cluster.md
@@ -2,8 +2,6 @@
 title: Create a cluster
 sidebar_position: 2
 description: Create a cluster for deployment
-tags:
-  - private networks
 ---
 
 # Create a cluster

--- a/docs/private-networks/tutorials/kubernetes/index.md
+++ b/docs/private-networks/tutorials/kubernetes/index.md
@@ -1,8 +1,6 @@
 ---
 title: Deploy a Besu private network with Kubernetes
 description: Deploying Besu with Kubernetes
-tags:
-  - private networks
 ---
 
 # Deploy Besu using Kubernetes

--- a/docs/private-networks/tutorials/kubernetes/maintenance.md
+++ b/docs/private-networks/tutorials/kubernetes/maintenance.md
@@ -2,8 +2,6 @@
 title: Maintenance
 sidebar_position: 5
 description: Maintenance for Besu on a Kubernetes cluster
-tags:
-  - private networks
 ---
 
 # Maintenance

--- a/docs/private-networks/tutorials/kubernetes/multi-cluster.md
+++ b/docs/private-networks/tutorials/kubernetes/multi-cluster.md
@@ -2,8 +2,6 @@
 title: Deploy Besu across multiple Kubernetes clusters across multiple cloud providers
 description: Deploy Besu across multiple Kubernetes clusters across multiple cloud providers
 sidebar_position: 7
-tags:
-  - private networks
 ---
 
 # Deploy Besu across multiple Kubernetes clusters across multiple cloud providers

--- a/docs/private-networks/tutorials/kubernetes/playground.md
+++ b/docs/private-networks/tutorials/kubernetes/playground.md
@@ -2,8 +2,6 @@
 title: Local playground
 sidebar_position: 1
 description: Deploying a Besu private network locally with Kubernetes
-tags:
-  - private networks
 ---
 
 # Deploy in a local environment

--- a/docs/private-networks/tutorials/kubernetes/production.md
+++ b/docs/private-networks/tutorials/kubernetes/production.md
@@ -2,8 +2,6 @@
 title: Production
 sidebar_position: 6
 description: Deploying Besu Helm Charts for production on a Kubernetes cluster
-tags:
-  - private networks
 ---
 
 # Deploy for production

--- a/docs/private-networks/tutorials/kubernetes/quorum-explorer.md
+++ b/docs/private-networks/tutorials/kubernetes/quorum-explorer.md
@@ -2,8 +2,6 @@
 title: Use the Quorum Explorer
 sidebar_position: 4
 description: Using the Quorum Explorer on a Kubernetes cluster
-tags:
-  - private networks
 ---
 
 # Use the Quorum Explorer

--- a/docs/private-networks/tutorials/permissioning/index.md
+++ b/docs/private-networks/tutorials/permissioning/index.md
@@ -3,8 +3,6 @@ title: Create a permissioned network
 sidebar_position: 1
 description: Besu create a permissioned network
 toc_max_heading_level: 3
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/qbft.md
+++ b/docs/private-networks/tutorials/qbft.md
@@ -2,8 +2,6 @@
 title: Create a QBFT network
 sidebar_position: 2
 description: Create a private network using the QBFT consensus protocol.
-tags:
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/private-networks/tutorials/quickstart.md
+++ b/docs/private-networks/tutorials/quickstart.md
@@ -2,8 +2,6 @@
 title: Quorum Developer Quickstart
 sidebar_position: 1
 description: Rapidly generate a local blockchain network using the Quickstart.
-tags:
-  - private networks
 ---
 
 import TestAccounts from '../../global/test_accounts.md';

--- a/docs/public-networks/.meta.yml
+++ b/docs/public-networks/.meta.yml
@@ -1,6 +1,0 @@
----
-# Meta items setting with yaml files is an insider only feature
-# see https://squidfunk.github.io/mkdocs-material/reference/#built-in-meta-plugin
-
-tags:
-  - public networks

--- a/docs/public-networks/concepts/data-storage-formats.md
+++ b/docs/public-networks/concepts/data-storage-formats.md
@@ -2,8 +2,6 @@
 title: Data storage formats
 sidebar_position: 3
 description: Learn about storing data using Forest of Tries and Bonsai Tries.
-tags:
-  - public networks
 ---
 
 # Data storage formats

--- a/docs/public-networks/concepts/events-and-logs.md
+++ b/docs/public-networks/concepts/events-and-logs.md
@@ -2,9 +2,6 @@
 title: Events and logs
 sidebar_position: 8
 description: Learn about events and logs in Besu.
-tags:
-  - public networks
-  - private networks
 ---
 
 # Events and logs

--- a/docs/public-networks/concepts/genesis-file.md
+++ b/docs/public-networks/concepts/genesis-file.md
@@ -2,9 +2,6 @@
 title: Genesis file
 sidebar_position: 9
 description: Learn about configuring a network using the genesis file.
-tags:
-  - public networks
-  - private networks
 ---
 
 # Genesis file

--- a/docs/public-networks/concepts/network-and-chain-id.md
+++ b/docs/public-networks/concepts/network-and-chain-id.md
@@ -2,9 +2,6 @@
 title: Network ID and chain ID
 sidebar_position: 7
 description: Learn about network ID and chain ID in Besu.
-tags:
-  - public networks
-  - private networks
 ---
 
 # Network ID and chain ID

--- a/docs/public-networks/concepts/node-clients.md
+++ b/docs/public-networks/concepts/node-clients.md
@@ -2,8 +2,6 @@
 title: Node clients
 sidebar_position: 1
 description: Learn about execution and consensus clients.
-tags:
-  - public networks
 ---
 
 # Node clients

--- a/docs/public-networks/concepts/node-keys.md
+++ b/docs/public-networks/concepts/node-keys.md
@@ -2,9 +2,6 @@
 title: Node keys
 sidebar_position: 10
 description: Learn about node public and private keys, and the node address.
-tags:
-  - public networks
-  - private networks
 ---
 
 # Node keys and node address

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -2,8 +2,6 @@
 title: Node synchronization
 sidebar_position: 4
 description: Learn about node synchronization for public networks.
-tags:
-  - public networks
 ---
 
 # Node synchronization

--- a/docs/public-networks/concepts/parallel-transaction-execution.md
+++ b/docs/public-networks/concepts/parallel-transaction-execution.md
@@ -2,7 +2,6 @@
 title: Parallel transaction execution
 sidebar_position: 5
 description: Learn about parallel transaction execution.
-- public networks
 ---
 
 # Parallel transaction execution

--- a/docs/public-networks/concepts/parallel-transaction-execution.md
+++ b/docs/public-networks/concepts/parallel-transaction-execution.md
@@ -2,7 +2,6 @@
 title: Parallel transaction execution
 sidebar_position: 5
 description: Learn about parallel transaction execution.
-tags:
 - public networks
 ---
 

--- a/docs/public-networks/concepts/plugins.md
+++ b/docs/public-networks/concepts/plugins.md
@@ -2,9 +2,6 @@
 title: Plugins
 sidebar_position: 6
 description: Plugins overview
-tags:
-  - public networks
-  - private networks
 ---
 
 # Plugins

--- a/docs/public-networks/concepts/proof-of-stake/attestations.md
+++ b/docs/public-networks/concepts/proof-of-stake/attestations.md
@@ -2,8 +2,6 @@
 title: Attestations
 sidebar_position: 1
 description: Proof of stake attestations
-tags:
-  - public networks
 ---
 
 # Attestations

--- a/docs/public-networks/concepts/proof-of-stake/index.md
+++ b/docs/public-networks/concepts/proof-of-stake/index.md
@@ -1,7 +1,5 @@
 ---
 description: Ethereum proof of stake consensus
-tags:
-  - public networks
 ---
 
 # Proof of stake consensus

--- a/docs/public-networks/concepts/transactions/pool.md
+++ b/docs/public-networks/concepts/transactions/pool.md
@@ -2,9 +2,6 @@
 title: Transaction pool
 sidebar_position: 2
 description: Transaction pool overview
-tags:
-  - public networks
-  - private networks
 ---
 
 # Transaction pool

--- a/docs/public-networks/concepts/transactions/types.md
+++ b/docs/public-networks/concepts/transactions/types.md
@@ -2,9 +2,6 @@
 title: Transaction types
 sidebar_position: 1
 description: Description of the different transaction types
-tags:
-  - public networks
-  - private networks
 ---
 
 # Transaction types

--- a/docs/public-networks/concepts/transactions/validation.md
+++ b/docs/public-networks/concepts/transactions/validation.md
@@ -2,9 +2,6 @@
 title: Transaction validation
 sidebar_position: 3
 description: What transaction validation and when
-tags:
-  - public networks
-  - private networks
 ---
 
 # Transaction validation

--- a/docs/public-networks/get-started/connect/index.md
+++ b/docs/public-networks/get-started/connect/index.md
@@ -1,7 +1,5 @@
 ---
 title: Connect to a network overview
-tags:
-  - public networks
 hide:
   - feedback
 ---

--- a/docs/public-networks/get-started/connect/mainnet.md
+++ b/docs/public-networks/get-started/connect/mainnet.md
@@ -2,8 +2,6 @@
 title: Connect to Mainnet
 sidebar_position: 2
 description: How to connect to Mainnet
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -2,8 +2,6 @@
 title: Connect to a testnet
 sidebar_position: 3
 Description: How to connect to a testnet
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/get-started/install/binary-distribution.md
+++ b/docs/public-networks/get-started/install/binary-distribution.md
@@ -2,8 +2,6 @@
 title: Install binary distribution
 sidebar_position: 2
 description: Install or upgrade Besu from binary distribution
-tags:
-  - public networks
 ---
 
 # Install binary distribution

--- a/docs/public-networks/get-started/install/index.md
+++ b/docs/public-networks/get-started/install/index.md
@@ -1,8 +1,6 @@
 ---
 title: Installation options
 description: Options for getting started with Besu
-tags:
-  - public networks
 ---
 
 # Installation options

--- a/docs/public-networks/get-started/install/run-docker-image.md
+++ b/docs/public-networks/get-started/install/run-docker-image.md
@@ -2,8 +2,6 @@
 title: Run Besu from Docker image
 sidebar_position: 1
 description: Run Besu using the official docker image
-tags:
-  - public networks
 ---
 
 # Run Besu from a Docker image

--- a/docs/public-networks/get-started/migrate-to-besu.md
+++ b/docs/public-networks/get-started/migrate-to-besu.md
@@ -1,7 +1,5 @@
 ---
 description: Migrate to Besu from a different Ethereum execution client.
-tags:
-  - public networks
 ---
 
 # Migrate to Besu

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -2,8 +2,6 @@
 title: Start Besu
 sidebar_position: 3
 description: Start Besu on a public Ethereum network.
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/get-started/system-requirements.md
+++ b/docs/public-networks/get-started/system-requirements.md
@@ -2,8 +2,6 @@
 title: System requirements
 sidebar_position: 1
 description: Ensure you meet the system requirements to sync and run Besu.
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/bonsai-limit-trie-logs.md
+++ b/docs/public-networks/how-to/bonsai-limit-trie-logs.md
@@ -2,8 +2,6 @@
 title: Reduce storage for Bonsai Tries
 sidebar_position: 9
 description: Reduce the size of your database when using Bonsai Tries
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/configure-besu/index.md
+++ b/docs/public-networks/how-to/configure-besu/index.md
@@ -2,9 +2,6 @@
 title: Configure Besu
 description: Specify options in the Besu configuration file.
 sidebar_position: 1
-tags:
-  - public networks
-  - private networks
 ---
 
 # Configure Besu

--- a/docs/public-networks/how-to/configure-besu/profile.md
+++ b/docs/public-networks/how-to/configure-besu/profile.md
@@ -1,9 +1,6 @@
 ---
 title: Use a profile 
 sidebar_position: 1
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use a profile 

--- a/docs/public-networks/how-to/configure-ha/index.md
+++ b/docs/public-networks/how-to/configure-ha/index.md
@@ -1,8 +1,5 @@
 ---
 description: Besu high availability
-tags:
-  - public networks
-  - private networks
 ---
 
 # High availability of JSON-RPC and RPC Pub/Sub APIs

--- a/docs/public-networks/how-to/configure-ha/sample-configuration.md
+++ b/docs/public-networks/how-to/configure-ha/sample-configuration.md
@@ -2,9 +2,6 @@
 title: Sample load balancer configurations
 sidebar_position: 1
 description: Sample load balancers
-tags:
-  - public networks
-  - private networks
 ---
 
 # Sample load balancer configurations

--- a/docs/public-networks/how-to/configure-java/install-update-java.md
+++ b/docs/public-networks/how-to/configure-java/install-update-java.md
@@ -1,9 +1,6 @@
 ---
 sidebar_position: 1
 description: Install or update Java for use with Besu
-tags:
-  - public networks
-  - private networks
 ---
 
 # Install and update Java

--- a/docs/public-networks/how-to/configure-java/java-flight-recorder.md
+++ b/docs/public-networks/how-to/configure-java/java-flight-recorder.md
@@ -2,9 +2,6 @@
 title: Use Java Flight Recorder
 sidebar_position: 4
 description: Using Java Flight Recorder with Besu
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use Java Flight Recorder

--- a/docs/public-networks/how-to/configure-java/manage-memory.md
+++ b/docs/public-networks/how-to/configure-java/manage-memory.md
@@ -2,9 +2,6 @@
 title: Manage JVM memory
 sidebar_position: 3
 description: Besu memory management
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/configure-java/pass-jvm-options.md
+++ b/docs/public-networks/how-to/configure-java/pass-jvm-options.md
@@ -2,9 +2,6 @@
 title: Pass JVM options
 sidebar_position: 2
 description: Passing Java virtual machine JVM options to Besu at runtime
-tags:
-  - public networks
-  - private networks
 ---
 
 # Pass JVM options

--- a/docs/public-networks/how-to/connect/configure-ports.md
+++ b/docs/public-networks/how-to/connect/configure-ports.md
@@ -2,9 +2,6 @@
 title: Configure ports
 sidebar_position: 2
 description: To enable communication you must expose Besu ports appropriately
-tags:
-  - public networks
-  - private networks
 ---
 
 # Configure ports

--- a/docs/public-networks/how-to/connect/manage-peers.md
+++ b/docs/public-networks/how-to/connect/manage-peers.md
@@ -2,9 +2,6 @@
 title: Manage peers
 sidebar_position: 3
 description: Managing Besu peers
-tags:
-  - public networks
-  - private networks
 ---
 
 # Manage peers

--- a/docs/public-networks/how-to/connect/specify-nat.md
+++ b/docs/public-networks/how-to/connect/specify-nat.md
@@ -2,9 +2,6 @@
 title: Specify NAT method
 sidebar_position: 4
 description: Configuring NAT with Besu
-tags:
-  - public networks
-  - private networks
 ---
 
 # Specify the NAT method

--- a/docs/public-networks/how-to/connect/static-nodes.md
+++ b/docs/public-networks/how-to/connect/static-nodes.md
@@ -2,9 +2,6 @@
 title: Configure static nodes
 sidebar_position: 1
 description: Configuring static nodes
-tags:
-  - public networks
-  - private networks
 ---
 
 # Static nodes

--- a/docs/public-networks/how-to/develop/client-libraries.md
+++ b/docs/public-networks/how-to/develop/client-libraries.md
@@ -2,9 +2,6 @@
 title: Use client libraries
 sidebar_position: 2
 description: Besu client libraries
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use client libraries

--- a/docs/public-networks/how-to/develop/hardhat.md
+++ b/docs/public-networks/how-to/develop/hardhat.md
@@ -2,9 +2,6 @@
 title: Use Hardhat
 sidebar_position: 1
 description: Using Besu with Hardhat
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use Hardhat

--- a/docs/public-networks/how-to/era1-file-full-sync.md
+++ b/docs/public-networks/how-to/era1-file-full-sync.md
@@ -2,8 +2,6 @@
 title: Import ERA1 files
 sidebar_position: 9
 description: Import pre-merge Ethereum history from ERA1 archive files when using Full sync
-tags:
-  - public networks
 ---
 
 When running [full sync](../concepts/node-sync.md#full-synchronization), node operators can optionally

--- a/docs/public-networks/how-to/monitor/index.md
+++ b/docs/public-networks/how-to/monitor/index.md
@@ -1,8 +1,5 @@
 ---
 description: Monitoring using metrics and logging
-tags:
-  - public networks
-  - private networks
 ---
 
 # Monitor Besu

--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -4,9 +4,6 @@ sidebar_position: 3
 description: Besu log level setting and log formatting
 path: blob/master/besu/src/main/resources/
 source: log4j2.xml
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use logging

--- a/docs/public-networks/how-to/monitor/metrics.md
+++ b/docs/public-networks/how-to/monitor/metrics.md
@@ -2,9 +2,6 @@
 title: Use metrics
 sidebar_position: 1
 description: Monitoring and metrics
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/monitor/understand-metrics.md
+++ b/docs/public-networks/how-to/monitor/understand-metrics.md
@@ -2,8 +2,6 @@
 title: Understand metrics
 sidebar_position: 2
 description: Understand Besu performance metrics
-tags:
-  - public networks
 ---
 
 # Understand metrics

--- a/docs/public-networks/how-to/pre-merge-history-expiry.md
+++ b/docs/public-networks/how-to/pre-merge-history-expiry.md
@@ -2,8 +2,6 @@
 title: Prune pre-merge history
 sidebar_position: 9
 description: Reduce the size of your database by removing pre-merge blocks from your blockchain
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/send-transactions.md
+++ b/docs/public-networks/how-to/send-transactions.md
@@ -2,8 +2,6 @@
 title: Create and send transactions
 sidebar_position: 4
 description: Send transactions using eth_call or eth_sendRawTransaction.
-tags:
-  - public networks
 ---
 
 # Create and send transactions

--- a/docs/public-networks/how-to/troubleshoot/evm-tool.md
+++ b/docs/public-networks/how-to/troubleshoot/evm-tool.md
@@ -2,9 +2,6 @@
 title: Use EVM tool
 sidebar_position: 1
 description: Besu EVM tool
-tags:
-  - public networks
-  - private networks
 ---
 
 # Use the EVM tool

--- a/docs/public-networks/how-to/troubleshoot/peering.md
+++ b/docs/public-networks/how-to/troubleshoot/peering.md
@@ -2,8 +2,6 @@
 title: Troubleshoot peering
 sidebar_position: 4
 description: How to troubleshoot peering
-tags:
-  - public networks
 ---
 
 # Troubleshoot peering

--- a/docs/public-networks/how-to/troubleshoot/performance.md
+++ b/docs/public-networks/how-to/troubleshoot/performance.md
@@ -2,8 +2,6 @@
 description: Troubleshoot poor performance and resource constraints.
 sidebar_label: Troubleshoot performance
 sidebar_position: 3
-tags:
-  - public networks
 ---
 
 # Troubleshoot performance

--- a/docs/public-networks/how-to/troubleshoot/trace-transactions.md
+++ b/docs/public-networks/how-to/troubleshoot/trace-transactions.md
@@ -2,9 +2,6 @@
 title: Trace transactions
 sidebar_position: 2
 description: How to trace transactions
-tags:
-  - public networks
-  - private networks
 ---
 
 # Trace transactions

--- a/docs/public-networks/how-to/upgrade-node.md
+++ b/docs/public-networks/how-to/upgrade-node.md
@@ -3,9 +3,6 @@ title: Upgrade Besu
 sidebar_position: 11
 description: Upgrade your Besu node to a new version.
 toc_max_heading_level: 2
-tags:
-  - public networks
-  - private networks
 ---
 
 # Upgrade your Besu node

--- a/docs/public-networks/how-to/use-besu-api/access-logs.md
+++ b/docs/public-networks/how-to/use-besu-api/access-logs.md
@@ -2,9 +2,6 @@
 title: Access logs using JSON-RPC
 sidebar_position: 5
 description: Accessing logs using the Besu API
-tags:
-  - public networks
-  - private networks
 ---
 
 # Access logs using the Besu API

--- a/docs/public-networks/how-to/use-besu-api/authenticate.md
+++ b/docs/public-networks/how-to/use-besu-api/authenticate.md
@@ -2,9 +2,6 @@
 title: Authenticate over JSON-RPC requests
 sidebar_position: 4
 description: Besu authentication and authorization for JSON-RPC
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/use-besu-api/graphql.md
+++ b/docs/public-networks/how-to/use-besu-api/graphql.md
@@ -2,9 +2,6 @@
 title: Use GraphQL over HTTP
 sidebar_position: 3
 description: How to access the Besu API using GraphQL
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/use-besu-api/index.md
+++ b/docs/public-networks/how-to/use-besu-api/index.md
@@ -1,8 +1,5 @@
 ---
 description: Besu API
-tags:
-  - public networks
-  - private networks
 ---
 
 # Access the Besu API

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -2,9 +2,6 @@
 title: Use JSON-RPC over HTTP, WS, and IPC
 sidebar_position: 1
 description: How to access the Besu API using JSON-RPC
-tags:
-  - public networks
-  - private networks
 ---
 
 import Postman from '../../../global/postman.md';

--- a/docs/public-networks/how-to/use-besu-api/rpc-pubsub.md
+++ b/docs/public-networks/how-to/use-besu-api/rpc-pubsub.md
@@ -2,9 +2,6 @@
 title: Use RPC Pub/Sub over WS and IPC
 sidebar_position: 2
 description: Using RPC Pub/Sub with Besu WebSockets and IPC
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/how-to/use-engine-api.md
+++ b/docs/public-networks/how-to/use-engine-api.md
@@ -2,8 +2,6 @@
 title: Use the Engine API
 sidebar_position: 2
 description: Use the Engine API to communicate with a consensus client.
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/index.md
+++ b/docs/public-networks/index.md
@@ -3,8 +3,6 @@ title: Public networks
 sidebar_position: 1
 sidebar_label: Introduction
 description: Public networks overview
-tags:
-  - public networks
 ---
 
 # Besu for public networks

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -3,9 +3,6 @@ title: Besu API
 sidebar_position: 2
 description: Besu JSON-RPC API methods reference
 toc_max_heading_level: 3
-tags:
-  - public networks
-  - private networks
 ---
 
 import Postman from '../../../global/postman.md'

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -1,9 +1,6 @@
 ---
 title: Objects
 description: Besu API objects reference
-tags:
-  - public networks
-  - private networks
 ---
 
 # Besu API objects

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2,9 +2,6 @@
 title: Options
 description: Besu command line interface reference
 sidebar_position: 1
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/reference/cli/subcommands.md
+++ b/docs/public-networks/reference/cli/subcommands.md
@@ -2,9 +2,6 @@
 title: Subcommands
 description: Besu command line interface subcommands
 sidebar_position: 2
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/reference/disclosure.md
+++ b/docs/public-networks/reference/disclosure.md
@@ -2,9 +2,6 @@
 title: Security disclosure policy
 sidebar_position: 8
 description: Besu responsible disclosure statement
-tags:
-  - public networks
-  - private networks
 ---
 
 # Security disclosure policy

--- a/docs/public-networks/reference/engine-api/index.md
+++ b/docs/public-networks/reference/engine-api/index.md
@@ -2,8 +2,6 @@
 title: Engine API
 description: Engine API methods reference
 toc_max_heading_level: 3
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/reference/engine-api/objects.md
+++ b/docs/public-networks/reference/engine-api/objects.md
@@ -1,8 +1,6 @@
 ---
 title: Objects
 description: Engine API objects reference
-tags:
-  - public networks
 ---
 
 # Engine API objects

--- a/docs/public-networks/reference/evm-tool.md
+++ b/docs/public-networks/reference/evm-tool.md
@@ -3,9 +3,6 @@ title: EVM tool options
 sidebar_position: 5
 toc_max_heading_level: 3
 description: Besu EVM tool options reference
-tags:
-  - public networks
-  - private networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/reference/genesis-items.md
+++ b/docs/public-networks/reference/genesis-items.md
@@ -2,9 +2,6 @@
 title: Genesis file items
 sidebar_position: 4
 description: Genesis file configuration items reference
-tags:
-  - public networks
-  - private networks
 ---
 
 # Genesis file items

--- a/docs/public-networks/reference/plugin-api-interfaces.md
+++ b/docs/public-networks/reference/plugin-api-interfaces.md
@@ -2,9 +2,6 @@
 title: Plugin API interfaces
 sidebar_position: 4
 description: Plugin interfaces
-tags:
-  - public networks
-  - private networks
 ---
 
 # Plugin API interfaces

--- a/docs/public-networks/reference/projects-using-besu.md
+++ b/docs/public-networks/reference/projects-using-besu.md
@@ -2,9 +2,6 @@
 title: Projects using Besu
 sidebar_position: 7
 description: List of projects using Besu
-tags:
-  - public networks
-  - private networks
 ---
 
 # Projects using Besu

--- a/docs/public-networks/reference/trace-types.md
+++ b/docs/public-networks/reference/trace-types.md
@@ -2,9 +2,6 @@
 title: Transaction trace types
 sidebar_position: 6
 description: Transaction trace types reference
-tags:
-  - public networks
-  - private networks
 ---
 
 # Transaction trace types

--- a/docs/public-networks/tutorials/aws-node-runners.md
+++ b/docs/public-networks/tutorials/aws-node-runners.md
@@ -2,8 +2,6 @@
 sidebar_position: 4
 description: Configure Ethereum nodes using AWS Blockchain Node Runners.
 toc_max_heading_level: 3
-tags:
-   - Public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/tutorials/besu-teku-mainnet.md
+++ b/docs/public-networks/tutorials/besu-teku-mainnet.md
@@ -2,8 +2,6 @@
 title: Run Besu and Teku on Mainnet
 sidebar_position: 1
 description: Run Besu and Teku on Ethereum Mainnet.
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -2,8 +2,6 @@
 title: Run Besu and Teku on a testnet
 sidebar_position: 2
 description: Run Besu and Teku on Ephemery , Hoodi or Sepolia testnet.
-tags:
-  - public networks
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/public-networks/tutorials/kubernetes.md
+++ b/docs/public-networks/tutorials/kubernetes.md
@@ -3,8 +3,6 @@ title: Deploy Besu using Kubernetes
 description: Deploy a Besu node using Kubernetes.
 sidebar_position: 3
 toc_max_heading_level: 3
-tags:
-  - public networks
 ---
 
 # Deploy a Besu public node using Kubernetes 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,7 @@ const config = {
       "classic",
       {
         docs: {
-          breadcrumbs: false,
+          breadcrumbs: true,
           sidebarPath: require.resolve("./sidebars.js"),
           // Set a base path separate from default /docs
           editUrl: "https://github.com/hyperledger/besu-docs/tree/main/",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -383,6 +383,18 @@ img {
   font-weight: var(--ifm-font-weight-semibold);
 }
 
+/* Match light mode navbar hover color to dark mode */
+html[data-theme="light"] .navbar__link:hover {
+  color: #8BB8FF;
+}
+
+/* Active top nav section highlighting */
+.navbar__link--active {
+  color: #fff !important;
+  border-bottom: 3px solid rgba(255, 255, 255, 0.9);
+  padding-bottom: calc(var(--ifm-navbar-padding-vertical) - 3px);
+}
+
 /* Search bar customization */
 .navbar__search-input {
   width: 14rem;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -391,7 +391,7 @@ html[data-theme="light"] .navbar__link:hover {
 /* Active top nav section highlighting */
 .navbar__link--active {
   color: #fff !important;
-  border-bottom: 3px solid rgba(255, 255, 255, 0.9);
+  border-bottom: 3px solid rgb(255 255 255 / 90%);
   padding-bottom: calc(var(--ifm-navbar-padding-vertical) - 3px);
 }
 

--- a/src/theme/DocBreadcrumbs/index.jsx
+++ b/src/theme/DocBreadcrumbs/index.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useSidebarBreadcrumbs } from "@docusaurus/plugin-content-docs/client";
+import { useHomePageRoute } from "@docusaurus/theme-common/internal";
+import { useLocation } from "@docusaurus/router";
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
+import DocBreadcrumbsStructuredData from "@theme/DocBreadcrumbs/StructuredData";
+import styles from "./styles.module.css";
+
+const SECTIONS = [
+  { pathPrefix: "/public-networks", label: "Public networks", href: "/public-networks" },
+  { pathPrefix: "/private-networks", label: "Private networks", href: "/private-networks" },
+];
+
+function getSectionItem(pathname) {
+  return SECTIONS.find((s) => pathname.startsWith(s.pathPrefix)) ?? null;
+}
+
+function BreadcrumbsItemLink({ children, href, isLast }) {
+  const className = "breadcrumbs__link";
+  if (isLast) {
+    return <span className={className}>{children}</span>;
+  }
+  return href ? (
+    <Link className={className} href={href}>
+      <span>{children}</span>
+    </Link>
+  ) : (
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({ children, active }) {
+  return (
+    <li
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}
+    >
+      {children}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs() {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  const { pathname } = useLocation();
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  const sectionItem = getSectionItem(pathname);
+
+  // Avoid duplicating the section label when the first breadcrumb already points
+  // to the section root (e.g. when viewing the /public-networks index page).
+  const firstHref = breadcrumbs[0]?.href;
+  const showSection = sectionItem && firstHref !== sectionItem.href;
+
+  const allItems = showSection
+    ? [{ label: sectionItem.label, href: sectionItem.href, _isSection: true }, ...breadcrumbs]
+    : breadcrumbs;
+
+  return (
+    <>
+      <DocBreadcrumbsStructuredData breadcrumbs={breadcrumbs} />
+      <nav
+        className={clsx(
+          ThemeClassNames.docs.docBreadcrumbs,
+          styles.breadcrumbsContainer,
+        )}
+        aria-label={translate({
+          id: "theme.docs.breadcrumbs.navAriaLabel",
+          message: "Breadcrumbs",
+          description: "The ARIA label for the breadcrumbs",
+        })}
+      >
+        <ul className="breadcrumbs">
+          {homePageRoute && <HomeBreadcrumbItem />}
+          {allItems.map((item, idx) => {
+            const isLast = idx === allItems.length - 1;
+            const href = item._isSection
+              ? item.href
+              : item.type === "category" && item.linkUnlisted
+              ? undefined
+              : item.href;
+            return (
+              <BreadcrumbsItem key={idx} active={isLast}>
+                <BreadcrumbsItemLink href={href} isLast={isLast}>
+                  {item.label}
+                </BreadcrumbsItemLink>
+              </BreadcrumbsItem>
+            );
+          })}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,4 @@
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,4 +1,5 @@
 .breadcrumbsContainer {
   --ifm-breadcrumb-size-multiplier: 0.8;
+
   margin-bottom: 0.8rem;
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes made in your pull request (PR) below. -->

- Update styles for top nav links to make it more clear which section you're in
- Remove tags (the links are pretty useless) in favor of breadcrumbs
- Swizzle breadcrumbs to include "Public networks" vs "Private networks" in the hierarchy (by default these are omitted because they use different sidebars)

Note: In the future, we may consider adding `_partials` files for overlapping content, to avoid these awkward index pages on the private network side: https://besu.hyperledger.org/private-networks/how-to. For now, let's table that large change until we have a better idea of the direction of our private network offering.

### Issue(s) fixed
<!-- Include the issue number that this PR fixes. {Example: Fixes #123} -->

Fixes #1955 

### Preview
<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

- https://besu-docs-6bdin23zc-hyperledger.vercel.app/public-networks
