### PR TITLE
Fix WebSocket enable option typo in API docs

### DIFF
--- a/docs/public-networks/how-to/use-besu-api/index.md
+++ b/docs/public-networks/how-to/use-besu-api/index.md
@@ -20,7 +20,7 @@ The following sections provide information about JSON-RPC, RPC Pub/Sub, and Grap
 
 ## Enable API access
 
-To enable API access, use the [`--rpc-http-enabled`](../../reference/cli/options.md#rpc-http-enabled), [`--ws-http-enabled`](../../reference/cli/options.md#rpc-ws-enabled), [`--graphql-http-enabled`](../../reference/cli/options.md#graphql-http-enabled), or the early access `--Xrpc-ipc-enabled` options.
+To enable API access, use the [`--rpc-http-enabled`](../../reference/cli/options.md#rpc-http-enabled), [`--rpc-ws-enabled`](../../reference/cli/options.md#rpc-ws-enabled), [`--graphql-http-enabled`](../../reference/cli/options.md#graphql-http-enabled), or the early access `--Xrpc-ipc-enabled` options.
 
 :::caution
 


### PR DESCRIPTION

## Description

Fixed the incorrect WebSocket enable option in the API access documentation.

Replaced:
--ws-http-enabled

With:
--rpc-ws-enabled

in the Enable API access section of:

docs/public-networks/how-to/use-besu-api/index.md

## Issue(s) fixed

Fixes #1975