### PR TITLE
Remove mentions of Holesky

### DIFF
--- a/docs/public-networks/concepts/network-and-chain-id.md
+++ b/docs/public-networks/concepts/network-and-chain-id.md
@@ -45,7 +45,7 @@ Besu sets the chain ID (and by default the network ID) automatically, using eith
 
 :::info
 
-The following networks and testnets are deprecated: ETC (Ethereum Classic), Holesky, and Mordor.
+The following networks and testnets are deprecated: ETC (Ethereum Classic) and Mordor.
 
 :::
 

--- a/docs/public-networks/get-started/connect/testnet.md
+++ b/docs/public-networks/get-started/connect/testnet.md
@@ -50,7 +50,6 @@ If you're also running the consensus client as a validator client, create a test
 (you can do this in [MetaMask](https://support.metamask.io/configure/accounts/how-to-add-accounts-in-your-wallet/)).
 Fund this address with testnet ETH (32 ETH and gas fees for each validator) using a faucet. See the faucets for the relevant testnet:
 
-- [Holesky](https://github.com/eth-clients/holesky)
 - [Hoodi](https://github.com/eth-clients/hoodi)
 - [Sepolia](https://github.com/eth-clients/sepolia)
 - [Ephemery](https://ephemery-faucet.pk910.de/)
@@ -188,7 +187,11 @@ If you're running the consensus client as a beacon node only, you're all set. If
 
 ### 6. Stake ETH
 
-Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Hoodi Staking Launchpad](https://hoodi.launchpad.ethereum.org/), or [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
+Stake your testnet ETH for one or more validators using the
+[Hoodi Staking Launchpad](https://hoodi.launchpad.ethereum.org/) or
+[Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
 
-You can check your validator status by searching your Ethereum address on the [Holesky explorer](https://holesky.beaconcha.in/),
-[Hoodi explorer](https://hoodi.etherscan.io/), or [Ephemery explorer](https://explorer.ephemery.dev/). It may take up to multiple days for your validator to be activated and start proposing blocks.
+You can check your validator status by searching your Ethereum address on the
+[Hoodi explorer](https://hoodi.etherscan.io/) or
+[Ephemery explorer](https://explorer.ephemery.dev/). It may take up to multiple days
+for your validator to be activated and start proposing blocks.

--- a/docs/public-networks/get-started/start-node.md
+++ b/docs/public-networks/get-started/start-node.md
@@ -29,7 +29,7 @@ Besu specifies the genesis configuration, and sets the network ID and bootnodes 
 
 :::info
 
-The following networks and testnets are deprecated: ETC (Ethereum Classic), Holesky, and Mordor.
+The following networks and testnets are deprecated: ETC (Ethereum Classic) and Mordor.
 
 :::
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -3189,7 +3189,7 @@ Values are case-insensitive, so either `mainnet` or `MAINNET` works.
 
 - You can't use the `--network` and [`--genesis-file`](#genesis-file) options at the same time.
 
-- The following networks and testnets are deprecated: ETC (Ethereum Classic), Holesky, and Mordor.
+- The following networks and testnets are deprecated: ETC (Ethereum Classic) and Mordor.
 
 :::
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -1,7 +1,7 @@
 ---
 title: Run Besu and Teku on a testnet
 sidebar_position: 2
-description: Run Besu and Teku on Ephemery , Hoodi or Sepolia testnet.
+description: Run Besu and Teku on the Ephemery, Hoodi, or Sepolia testnets.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -133,11 +133,11 @@ To run Teku as a beacon node only (without validator duties), run the following 
 
 <Tabs>
 
-<TabItem value="Holesky" label="Holesky" default>
+<TabItem value="Hoodi" label="Hoodi" default>
 
 ```bash
 teku \
-  --network=holesky                            \
+  --network=hoodi                              \
   --ee-endpoint=http://localhost:8551          \
   --ee-jwt-secret-file=<path to jwtsecret.hex> \
   --metrics-enabled=true                       \
@@ -284,9 +284,14 @@ If you're running Teku as a beacon node only, you're all set. If you're also run
 
 ## 7. Stake ETH
 
-Stake your testnet ETH for one or more validators using the [Holesky Staking Launchpad](https://holesky.launchpad.ethereum.org/), [Hoodi Staking Launchpad](https://hoodi.launchpad.ethereum.org/), or [Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
+Stake your testnet ETH for one or more validators using the
+[Hoodi Staking Launchpad](https://hoodi.launchpad.ethereum.org/) or
+[Ephemery Staking Launchpad](https://launchpad.ephemery.dev/).
 
-You can check your validator status by searching your Ethereum address on the [Holesky explorer](https://holesky.beaconcha.in/), [Hoodi explorer](https://hoodi.etherscan.io/), or [Ephemery explorer](https://explorer.ephemery.dev/). It may take up to multiple days for your validator to be activated and start proposing blocks.
+You can check your validator status by searching your Ethereum address on the
+[Hoodi explorer](https://hoodi.etherscan.io/) or
+[Ephemery explorer](https://explorer.ephemery.dev/). It may take up to multiple days
+for your validator to be activated and start proposing blocks.
 
 <!--links-->
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -1,7 +1,7 @@
 ---
 title: Run Besu and Teku on a testnet
 sidebar_position: 2
-description: Run Besu and Teku on the Ephemery, Hoodi, or Sepolia testnets.
+description: Run Besu and Teku on Ephemery, Hoodi, or Sepolia testnet.
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
Holesky has moved from deprecated to unsupported, so this PR removes remaining instances of it.

Fixes #1985.