### PR TITLE
Deprecate `min-block-occupancy-ratio`

### DIFF
--- a/.cursor/rules/markdown-formatting.mdc
+++ b/.cursor/rules/markdown-formatting.mdc
@@ -40,9 +40,15 @@ for full details. The rules below cover the most common conventions.
 
 ## Admonitions
 
-- Use Docusaurus admonitions: `:::note`, `:::tip`, `:::caution`, `:::info`, `:::danger`.
+- Use Docusaurus admonitions: `:::note`, `:::tip`, `:::caution`, `:::info`, `:::warning`,
+  `:::danger`.
 - Add a custom title on the same line only when it helps scanning (for example,
   `:::caution important`).
+- For deprecated features or content, use `:::warning Deprecated`.
+  State that the feature or content is deprecated and will be removed in a future release.
+- Do not add `(Deprecated)` to page titles, headings, or sidebar labels.
+  If removing `(Deprecated)` from an existing heading would change an anchor link, preserve the old
+  anchor with an explicit heading ID.
 - Do not nest admonitions.
 
 ## Tables

--- a/.cursor/rules/markdown-formatting.mdc
+++ b/.cursor/rules/markdown-formatting.mdc
@@ -40,15 +40,11 @@ for full details. The rules below cover the most common conventions.
 
 ## Admonitions
 
-- Use Docusaurus admonitions: `:::note`, `:::tip`, `:::caution`, `:::info`, `:::warning`,
-  `:::danger`.
+- Use Docusaurus admonitions: `:::note`, `:::tip`, `:::caution`, `:::warning`, `:::info`, and `:::danger`.
 - Add a custom title on the same line only when it helps scanning (for example,
   `:::caution important`).
 - For deprecated features or content, use `:::warning Deprecated`.
   State that the feature or content is deprecated and will be removed in a future release.
-- Do not add `(Deprecated)` to page titles, headings, or sidebar labels.
-  If removing `(Deprecated)` from an existing heading would change an anchor link, preserve the old
-  anchor with an explicit heading ID.
 - Do not nest admonitions.
 
 ## Tables

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2889,7 +2889,6 @@ Besu recognizes this option, but it has no effect.
 
 Besu ignores the `--min-block-occupancy-ratio` option for proof-of-stake networks, such as Ethereum Mainnet.
 
-:::
 
 ### `min-gas-price`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2877,6 +2877,14 @@ min-block-occupancy-ratio="0.5"
 
 Minimum occupancy ratio for a mined block if the transaction pool is not empty. When filling a block during mining, the occupancy ratio indicates the threshold at which the node stops waiting for smaller transactions to fill the remaining space. The default is 0.8.
 
+:::warning Deprecated
+
+The `--min-block-occupancy-ratio` option is deprecated and will be removed in a
+future release.
+Besu recognizes this option, but it has no effect.
+
+:::
+
 :::note
 
 Besu ignores the `--min-block-occupancy-ratio` option for proof-of-stake networks, such as Ethereum Mainnet.

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -2885,11 +2885,6 @@ Besu recognizes this option, but it has no effect.
 
 :::
 
-:::note
-
-Besu ignores the `--min-block-occupancy-ratio` option for proof-of-stake networks, such as Ethereum Mainnet.
-
-
 ### `min-gas-price`
 
 <Tabs>


### PR DESCRIPTION
- Add a `Deprecated` warning admonition for `--min-block-occupancy-ratio`.
- Document the deprecation admonition pattern in the Cursor Markdown formatting rule.

Fixes besu-eth/besu-docs#1984.
