### PR TITLE
Improve agent readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node scripts/copy-md-to-build.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/copy-md-to-build.js
+++ b/scripts/copy-md-to-build.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: copy source .md files into the build output so that
+ * appending ".md" to any documentation URL returns the raw markdown source.
+ *
+ * Docusaurus URL mapping (routeBasePath "/", path "./docs"):
+ *   docs/<area>/path/to/page.md   → build/<area>/path/to/page.md
+ *   docs/<area>/path/to/dir/index.md → build/<area>/path/to/dir.md
+ *
+ * This lets agents request, e.g.:
+ *   https://besu.hyperledger.org/public-networks/get-started/install.md
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DOCS_DIR = path.join(__dirname, "..", "docs");
+const BUILD_DIR = path.join(__dirname, "..", "build");
+
+// Docusaurus exclude patterns (from docusaurus.config.js)
+const SKIP_PREFIXES = ["_"];
+
+// Directive prepended after frontmatter so agents that fetch .md URLs
+// can discover the documentation index and other markdown pages.
+const AGENT_DIRECTIVE =
+  "> For AI agents: a documentation index is available at " +
+  "[/llms.txt](/llms.txt). " +
+  "Append `.md` to any documentation URL to get the markdown source.\n\n";
+
+let copied = 0;
+let skipped = 0;
+
+function shouldSkip(relPath) {
+  return relPath.split(path.sep).some((segment) =>
+    SKIP_PREFIXES.some((prefix) => segment.startsWith(prefix))
+  );
+}
+
+/**
+ * Insert the agent directive after the YAML frontmatter block (--- ... ---).
+ * If no frontmatter is present, prepend to the start of the file.
+ */
+function addDirective(content) {
+  // Frontmatter starts at position 0 with "---\n" and ends with "\n---\n"
+  if (content.startsWith("---\n") || content.startsWith("---\r\n")) {
+    const closingIdx = content.indexOf("\n---\n", 3);
+    if (closingIdx !== -1) {
+      const insertAt = closingIdx + 5; // after "\n---\n"
+      return content.slice(0, insertAt) + "\n" + AGENT_DIRECTIVE + content.slice(insertAt);
+    }
+  }
+  return AGENT_DIRECTIVE + content;
+}
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      const rel = path.relative(DOCS_DIR, fullPath);
+
+      if (shouldSkip(rel)) {
+        skipped++;
+        continue;
+      }
+
+      let destRel;
+      if (entry.name === "index.md") {
+        const parentRel = path.dirname(rel);
+        destRel = parentRel === "." ? "index.md" : `${parentRel}.md`;
+      } else {
+        destRel = rel;
+      }
+
+      const destPath = path.join(BUILD_DIR, destRel);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      const content = fs.readFileSync(fullPath, "utf8");
+      fs.writeFileSync(destPath, addDirective(content), "utf8");
+      copied++;
+    }
+  }
+}
+
+walk(DOCS_DIR);
+console.log(
+  `copy-md-to-build: copied ${copied} files, skipped ${skipped} files`
+);

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "@docusaurus/Link";
 import AskAiButton from "@site/src/components/AskAiButton";
 
 const agentDirectiveStyle = {
@@ -18,7 +19,7 @@ export default function Root({ children }) {
     <>
       <div style={agentDirectiveStyle}>
         For AI agents: a documentation index is available at{" "}
-        <a href="/llms.txt">/llms.txt</a>. Markdown versions of pages are
+        <Link to="/llms.txt">/llms.txt</Link>. Markdown versions of pages are
         available by appending <code>.md</code> to any documentation URL.
       </div>
       {children}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,9 +1,26 @@
 import React from "react";
 import AskAiButton from "@site/src/components/AskAiButton";
 
+const agentDirectiveStyle = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  borderWidth: 0,
+};
+
 export default function Root({ children }) {
   return (
     <>
+      <div style={agentDirectiveStyle}>
+        For AI agents: a documentation index is available at{" "}
+        <a href="/llms.txt">/llms.txt</a>. Markdown versions of pages are
+        available by appending <code>.md</code> to any documentation URL.
+      </div>
       {children}
       <AskAiButton />
     </>

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "@docusaurus/Link";
 import AskAiButton from "@site/src/components/AskAiButton";
 
 const agentDirectiveStyle = {
@@ -19,7 +18,8 @@ export default function Root({ children }) {
     <>
       <div style={agentDirectiveStyle}>
         For AI agents: a documentation index is available at{" "}
-        <Link to="/llms.txt">/llms.txt</Link>. Markdown versions of pages are
+        {/* eslint-disable-next-line @docusaurus/no-html-links */}
+        <a href="/llms.txt">/llms.txt</a>. Markdown versions of pages are
         available by appending <code>.md</code> to any documentation URL.
       </div>
       {children}

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
       ]
     },
     {
-      "source": "/index.md",
+      "source": "/(.*)\\.md",
       "headers": [
         {
           "key": "Content-Type",
@@ -83,6 +83,17 @@
         }
       ],
       "destination": "/index.md"
+    },
+    {
+      "source": "/:path+",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/:path+.md"
     }
   ]
 }


### PR DESCRIPTION
## Description
Improves agent readability for the Besu docs site by addressing several checks from the [agent-friendly documentation spec](https://agentdocsspec.com/spec/).
- **`scripts/copy-md-to-build.js`** (new): Post-build script that mirrors every source `.md` file from `docs/` into `build/` at the URL-equivalent path (`docs/foo/index.md` → `build/foo.md`). This makes raw markdown available at `.md` URL variants for every documentation page. The script also prepends a blockquote directive to each copied file pointing agents to `/llms.txt`.
- **`vercel.json`**: Adds a `Content-Type: text/markdown` header for all `*.md` paths, and a new rewrite rule that serves the `.md` version of any page when agents send `Accept: text/markdown`. Agents that explicitly request markdown (Claude Code, Cursor, OpenCode) now receive it automatically.
- **`package.json`**: Wires the copy script into the build (`docusaurus build && node scripts/copy-md-to-build.js`) so markdown files stay in sync on every deploy.
- **`src/theme/Root.js`**: Adds a visually-hidden `<div>` to every HTML page pointing agents to `/llms.txt` and noting that `.md` URL variants are available. Uses CSS clip-rect so it is invisible to human readers but present in the DOM and in any HTML-to-markdown conversion.
