### PR TITLE
Fix: Java 25 requirement

### DIFF
--- a/docs/private-networks/get-started/install/binary-distribution.md
+++ b/docs/private-networks/get-started/install/binary-distribution.md
@@ -18,7 +18,8 @@ sidebar_position: 3
 Besu supports:
 
 - MacOS High Sierra 10.13 or later versions.
-- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
+- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually
+    install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
 
 :::
 

--- a/docs/private-networks/get-started/install/binary-distribution.md
+++ b/docs/private-networks/get-started/install/binary-distribution.md
@@ -18,7 +18,7 @@ sidebar_position: 3
 Besu supports:
 
 - MacOS High Sierra 10.13 or later versions.
-- Java 21+. You can install Java using `brew install openjdk@21`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
+- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
 
 :::
 
@@ -65,7 +65,7 @@ besu --help
 
 ### Prerequisites
 
-- [Java JDK 17+](https://www.oracle.com/java/technologies/downloads/)
+- [Java JDK 25+](https://www.oracle.com/java/technologies/downloads/)
 
 :::note Linux open file limit
 

--- a/docs/public-networks/get-started/install/binary-distribution.md
+++ b/docs/public-networks/get-started/install/binary-distribution.md
@@ -18,7 +18,7 @@ description: Install or upgrade Besu from binary distribution
 Besu supports:
 
 - MacOS High Sierra 10.13 or later versions.
-- Java 21+. You can install Java using `brew install openjdk@21`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
+- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
 
 :::
 
@@ -62,7 +62,7 @@ besu --help
 
 ### Prerequisites
 
-- [Java JDK 21+](https://www.oracle.com/java/technologies/downloads/)
+- [Java JDK 25+](https://www.oracle.com/java/technologies/downloads/)
 
 :::note Linux open file limit
 

--- a/docs/public-networks/get-started/install/binary-distribution.md
+++ b/docs/public-networks/get-started/install/binary-distribution.md
@@ -18,7 +18,8 @@ description: Install or upgrade Besu from binary distribution
 Besu supports:
 
 - MacOS High Sierra 10.13 or later versions.
-- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
+- Java 25+. You can install Java using `brew install openjdk@25`. Alternatively, you can manually
+    install the [Java JDK](https://www.oracle.com/java/technologies/downloads).
 
 :::
 
@@ -66,13 +67,16 @@ besu --help
 
 :::note Linux open file limit
 
-If synchronizing to Mainnet on Linux or other chains with large data requirements, increase the maximum number of open files allowed using `ulimit`. If the open files limit is not high enough, a `Too many open files` RocksDB exception occurs.
+If synchronizing to Mainnet on Linux or other chains with large data requirements, increase the
+maximum number of open files allowed using `ulimit`. If the open files limit is not high enough, a
+`Too many open files` RocksDB exception occurs.
 
 :::
 
 :::tip
 
-We recommend installing [jemalloc](https://jemalloc.net/) to reduce memory usage. If using Ubuntu, you can install it with the command: `apt install libjemalloc-dev`.
+We recommend installing [jemalloc](https://jemalloc.net/) to reduce memory usage. If using Ubuntu, you
+can install it with the command: `apt install libjemalloc-dev`.
 
 :::
 

--- a/docs/public-networks/get-started/system-requirements.md
+++ b/docs/public-networks/get-started/system-requirements.md
@@ -19,8 +19,8 @@ CPU requirements are highest when syncing to the network and typically reduce af
 
 ## Java distribution and installation
 
-Besu requires an installation of Java 21+ to run.
-We currently recommend two Java distributions, [OpenJDK 21](https://jdk.java.net/21/) and
+Besu requires an installation of Java 25+ to run.
+We currently recommend two Java distributions, [OpenJDK 25](https://jdk.java.net/25/) and
 [OpenJ9](https://www.eclipse.org/openj9/), though you can experiment based on your needs.
 
 OpenJDK is the default for many Java users and is balanced in performance and garbage collection.
@@ -35,12 +35,12 @@ If you have less RAM:
 If you have OpenJDK installed or need a fresh installation of OpenJ9, you can pick up the OpenJ9
 docker image, or install the OpenJ9 JDK using the following steps:
 
-1. Get the [binaries](https://github.com/ibmruntimes/semeru21-certified-binaries/releases) corresponding to
+1. Get the [binaries](https://github.com/ibmruntimes/semeru25-certified-binaries/releases) corresponding to
    your OS architecture.
    For example:
 
     ```bash
-    wget https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.3%2B9_openj9-0.44.0/ibm-semeru-certified-jdk_x64_linux_21.0.3.0.tar.gz
+    wget https://github.com/ibmruntimes/semeru25-certified-binaries/releases/download/jdk-25.0.3.0/ibm-semeru-certified-jdk_x64_linux_25.0.3.0.tar.gz
     ```
 2. Uncompress the binaries:
 
@@ -55,7 +55,7 @@ docker image, or install the OpenJ9 JDK using the following steps:
     <TabItem value="Example" label="Example">
 
     ```bash
-    tar -xvf ibm-semeru-certified-jdk_x64_linux_21.0.3.0.tar.gz
+    tar -xvf ibm-semeru-certified-jdk_x64_linux_25.0.3.0.tar.gz
     ```
 
     </TabItem>
@@ -74,7 +74,7 @@ docker image, or install the OpenJ9 JDK using the following steps:
     <TabItem value="Example" label="Example">
 
     ```bash
-    sudo cp -r jdk-21.0.3+9/ /usr/bin/
+    sudo cp -r jdk-25.0.3+9/ /usr/bin/
     ```
 
     </TabItem>
@@ -94,7 +94,7 @@ docker image, or install the OpenJ9 JDK using the following steps:
     <TabItem value="Example" label="Example">
 
     ```bash
-    sudo update-alternatives --install "/usr/bin/java" "java" "/usr/bin/jdk-21.0.3+9/bin/java"
+    sudo update-alternatives --install "/usr/bin/java" "java" "/usr/bin/jdk-25.0.3+9/bin/java"
     ```
 
     </TabItem>
@@ -114,7 +114,7 @@ docker image, or install the OpenJ9 JDK using the following steps:
     <TabItem value="Example" label="Example">
 
     ```bash
-    export JAVA_HOME=/usr/bin/jdk-21.0.3+9
+    export JAVA_HOME=/usr/bin/jdk-25.0.3+9
     ```
 
     </TabItem>

--- a/docs/public-networks/how-to/configure-java/install-update-java.md
+++ b/docs/public-networks/how-to/configure-java/install-update-java.md
@@ -8,7 +8,7 @@ description: Install or update Java for use with Besu
 There are many flavors of Java and the Java Virtual Machine (JVM) that work with Besu.
 They might impact performance, start time, and more.
 Consider the options carefully when installing Java on your host machine.
-Currently, [we recommend Java 21](../../get-started/system-requirements.md#java-distribution-and-installation).
+Currently, [we recommend Java 25](../../get-started/system-requirements.md#java-distribution-and-installation).
 
 ## Install Java
 
@@ -17,7 +17,7 @@ If you are running Besu outside a virtual environment, like Docker, you must hav
 the host machine.
 
 :::tip
-Download [OpenJDK 21](https://jdk.java.net/21/).
+Download [OpenJDK 25](https://jdk.java.net/25/).
 :::
 
 You can find platform-specific installation instructions with the download.
@@ -44,7 +44,7 @@ You can install OpenJDK on Ubuntu using the `apt-get` command.
 3. If no version is returned, use `apt` to install the preferred version. 
 
     ```bash
-    sudo apt-get install openjdk-21-jdk
+    sudo apt-get install openjdk-25-jdk
     ```
 
 4. Confirm the installation:
@@ -84,7 +84,7 @@ You can install OpenJDK on MacOS using Homebrew.
 1. With `brew` installed, run:
 
     ```bash
-    brew install openjdk@21
+    brew install openjdk@25
     ```
 
     You can target another version if you prefer. 
@@ -125,12 +125,12 @@ You can update Java on MacOS using Homebrew.
     brew ls
     ```
 
-2. To update the JDK version (for example, from 17 to 21), uninstall the old version and reinstall
+2. To update the JDK version (for example, from 21 to 25), uninstall the old version and reinstall
     the target version:
 
     ```bash
-    brew uninstall openjdk@17
-    brew install openjdk@21
+    brew uninstall openjdk@21
+    brew install openjdk@25
     ```
 
     :::note

--- a/docs/public-networks/tutorials/besu-teku-mainnet.md
+++ b/docs/public-networks/tutorials/besu-teku-mainnet.md
@@ -15,7 +15,7 @@ Run Besu as an [execution client](../concepts/node-clients.md#execution-clients)
 
 Install [Besu](../get-started/install/binary-distribution.md) and [Teku](https://docs.teku.consensys.net/HowTo/Get-Started/Installation-Options/Install-Binaries/).
 
-Ensure you meet the prerequisites for the installation option you use. For example, you must have Java 21+ if using the Besu and Teku binary distributions.
+Ensure you meet the prerequisites for the installation option you use. For example, you must have Java 25+ if using the Besu and Teku binary distributions.
 
 Ensure you meet the [system requirements for Besu on public networks](../get-started/system-requirements.md).
 

--- a/docs/public-networks/tutorials/besu-teku-testnet.md
+++ b/docs/public-networks/tutorials/besu-teku-testnet.md
@@ -21,7 +21,7 @@ Sepolia is a permissioned network and you can't run a validator client on it wit
 
 Install [Besu](../get-started/install/binary-distribution.md) and [Teku](https://docs.teku.consensys.net/HowTo/Get-Started/Installation-Options/Install-Binaries/).
 
-Ensure you meet the prerequisites for the installation option you use. For example, you must have Java 21+ if using the Besu and Teku binary distributions.
+Ensure you meet the prerequisites for the installation option you use. For example, you must have Java 25+ if using the Besu and Teku binary distributions.
 
 Ensure you meet the [system requirements for Besu on public networks](../get-started/system-requirements.md).
 


### PR DESCRIPTION
## Description

Besu now requires Java 25 to build and run.

## Related issue(s)

Fixes #2022 

