### PR TITLE
Add Besu Developer Quickstart tutorial

### DIFF
--- a/docs/private-networks/how-to/monitor/chainlens.md
+++ b/docs/private-networks/how-to/monitor/chainlens.md
@@ -7,9 +7,7 @@ description: Use Chainlens Explorer on a Besu network
 # Use Chainlens Blockchain Explorer
 
 [Chainlens Blockchain Explorer](https://chainlens.com/) supports public and private EVM networks.
-This page describes how to use the free version of Chainlens with its built-in support for
-Besu networks created using the
-[Developer Quickstart](../../tutorials/quickstart.md).
+You can include Chainlens when generating a private network using the [Developer Quickstart](../../tutorials/quickstart.md).
 
 Chainlens provides an overview of the entire network, including block information, contract
 metadata, transaction searches, and [more](https://chainlens.com/).
@@ -25,35 +23,24 @@ to RPC nodes.
 
 ## Start Chainlens
 
-Clone the [Chainlens GitHub repository](https://github.com/web3labs/chainlens-free):
+Generate a private network using the [Developer Quickstart](../../tutorials/quickstart.md), with Chainlens enabled:
 
 ```bash
-git clone https://github.com/web3labs/chainlens-free
+npx @consensys-software/besu-dev-quickstart --networkType private --outputPath ./besu-test-network --otel false --chainlens true
 ```
 
-The repository contains a `docker-compose` directory to allow Chainlens to start with a Developer
-Quickstart test network.
-From the `docker-compose` directory, run the following command:
+Start the generated network:
 
 ```bash
-NODE_ENDPOINT=http://rpcnode:8545 docker-compose -f docker-compose.yml -f chainlens-extensions/docker-compose-quorum-dev-quickstart.yml up
+cd besu-test-network
+./run.sh
 ```
 
-This command does two things:
+Open `http://localhost:8081/dashboard` in your browser.
+Chainlens may take a few minutes to index the latest blocks after the containers start.
 
-- Sets up the node endpoint
-- Tells Docker to run by using the two Docker Compose files provided
-
-The first `docker-compose.yml` file in the command contains all the services required for Chainlens.
-
-The second file named `docker-compose-quorum-dev-quickstart` contains the network settings required to start
-Chainlens on the same network as the Besu development node.
-
-Next, open `http://localhost/` on your browser.
-You’ll see the new initialization page while it boots up.
-This may take 5–10 minutes for the all services to start and the ingestion sync to complete.
-
-![`Chainlens_loading`](../../../assets/images/chainlens-loading.png)
+If you already generated a private network without Chainlens, generate a new quickstart directory with `--chainlens true`.
+The Developer Quickstart adds the Chainlens services to the Docker Compose file at generation time.
 
 ## View on Chainlens
 
@@ -65,21 +52,13 @@ Screenshots in this section are taken from the Chainlens Holesky network.
 
 The **Dashboard** page provides an aggregated view of network activities.
 
-![`Chainlens_dashboard`](../../../assets/images/chainlens-dashboard.png)
-
-The **Network** page provides an overview of the network status and connected peers.
-This page is disabled by default, and is only visible if you set `DISPLAY_NETWORK_TAB=enabled` using
-the following command:
-
-```bash
-NODE_ENDPOINT=http://member1besu:8545 DISPLAY_NETWORK_TAB=enabled docker-compose -f docker-compose.yml -f chainlens-extensions/docker-compose-quorum-dev-quickstart.yml up
-```
+![Chainlens dashboard](../../../assets/images/chainlens-dashboard.png)
 
 The **Blocks** page shows a real-time view of the finalized blocks.
 
 ![Chainlens blocks](../../../assets/images/chainlens-block.png)
 
-You can view a given block details by selecting a block hash or number.
+You can view block details by selecting a block hash or number.
 
 ![Chainlens block details](../../../assets/images/chainlens-block-details.png)
 
@@ -95,7 +74,7 @@ The **Contracts** page shows all the smart contracts deployed on the network.
 
 ![Chainlens contracts](../../../assets/images/chainlens-contracts.png)
 
-You can view a smart contract details by selecting the contract address.
+You can view smart contract details by selecting the contract address.
 
 ![Chainlens contract details](../../../assets/images/chainlens-contract-details.png)
 
@@ -105,8 +84,9 @@ The **Events** page shows all the events generated on the network.
 
 ## Stop Chainlens
 
-To stop all the services from running, run the following command:
+Chainlens runs as part of the generated quickstart network.
+Stop the quickstart containers to stop Chainlens:
 
 ```bash
-docker-compose down
+./stop.sh
 ```

--- a/docs/private-networks/how-to/monitor/elastic-stack.md
+++ b/docs/private-networks/how-to/monitor/elastic-stack.md
@@ -6,28 +6,22 @@ description: Using Elastic Stack (ELK) with Besu
 
 # Use Elastic Stack
 
-[Elastic Stack] (ELK) is an open-source log management platform that is available when using the [Developer Quickstart](../../tutorials/quickstart.md).
+[Elastic Stack](https://www.elastic.co/elastic-stack/) (ELK) is an open-source log management platform you can use with Besu.
+To use ELK, configure the following for your deployment:
 
-The [Filebeat] configuration ingests logs and the [Metricbeat] configuration collects metrics from the nodes at regular defined intervals and outputs them to Redis for storage. Redis provides a highly available mechanism enabling storage by any of the Elastic Beats and pulled by Logstash as required.
+- **Filebeat** - This configuration ingests logs.
+  See the [example Filebeat configuration](https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/filebeat/filebeat.yml).
 
-The [pipeline configuration] defines the JSON format used for Besu logs and automatically picks up any new log fields.
+- **Metricbeat** - This configuration collects metrics from the nodes at regular defined intervals and outputs them to Redis for storage.
+  Redis provides a highly available mechanism enabling storage by any of the Elastic Beats and pulled by Logstash as required.
+  See the [example Metricbeat configuration](https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/metricbeat/metricbeat.yml).
 
-:::note
+- **Pipeline configuration** - This defines the JSON format used for Besu logs and automatically picks up any new log fields.
+  See the [example pipeline configuration](https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/logstash/pipeline/20_besu.conf).
 
-The pipeline configuration must match the your log format. If using the default log format, you can use the [grok plugin](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html) to extract the log fields.
+  :::note
 
-:::
+  The pipeline configuration must match the your log format.
+  If using the default log format, you can use the [Grok plugin](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html) to extract the log fields.
 
-To see the Besu Quickstart network logs in Kibana:
-
-1. [Start the Developer Quickstart with Besu](../../tutorials/quickstart.md), selecting ELK monitoring.
-1. Open the [`Kibana logs address`](http://localhost:5601/app/kibana#/discover) listed by the sample networks `list.sh` script. The logs display in Kibana.
-
-   ![Kibana](../../../assets/images/KibanaQuickstart.png)
-
-<!-- Links -->
-
-[Filebeat]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/filebeat/filebeat.yml
-[Metricbeat]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/metricbeat/metricbeat.yml
-[pipeline configuration]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/common/logstash/pipeline/20_besu.conf
-[Elastic Stack]: https://www.elastic.co/what-is/elk-stack
+  :::

--- a/docs/private-networks/how-to/monitor/loki.md
+++ b/docs/private-networks/how-to/monitor/loki.md
@@ -7,29 +7,24 @@ description: Using Grafana Loki log management platform with Besu
 # Grafana Loki
 
 [Grafana Loki] is an open-source log management platform that is available when using the [Developer Quickstart](../../tutorials/quickstart.md).
+The generated quickstart network uses Grafana Alloy to collect Besu logs and send them to Loki.
 
-The [Promtail configuration] ingests logs at regular defined intervals and outputs them to [Loki] for storage.
+## View quickstart logs in Loki
 
-The `pipeline configuration` in Promtail defines pipeline stages that can collate logs natively or using the JSON format.
+1. Generate a private network using the [Developer Quickstart](../../tutorials/quickstart.md).
+2. Open the Grafana logs URL listed by `./list.sh`.
+   The URL uses Grafana Explore:
 
-:::note
+   ```text
+   http://localhost:3000/a/grafana-lokiexplore-app/explore
+   ```
 
-If using the pipeline regex stage in `Promtail`, configuration must match your log format.
+3. Select the Loki data source if Grafana doesn't select it automatically.
 
-:::
-
-To view the GoQuorum Quickstart network logs in Loki:
-
-1. [Start the Developer Quickstart with Besu](../../tutorials/quickstart.md), selecting Loki monitoring.
-2. Open the [`Grafana Loki address`](http://localhost:3000/d/Ak6eXLsPxFemKYKEXfcH/quorum-logs-loki?orgId=1&var-app=besu&var-search=&from=now-15m&to=now) listed by the sample networks `list.sh` script.
-
-   The logs display in Loki.
+   The logs display in Grafana.
 
    ![Loki logs](../../../assets/images/grafana_loki.png)
 
 <!-- Links -->
 
-[Promtail configuration]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/master/files/common/promtail/promtail.yml
-[pipeline configuration]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/master/files/common/promtail/promtail.yml
-[Loki]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/master/files/common/loki/loki.yml
 [Grafana Loki]: https://grafana.com/oss/loki/

--- a/docs/private-networks/how-to/monitor/splunk.md
+++ b/docs/private-networks/how-to/monitor/splunk.md
@@ -11,18 +11,8 @@ description: Send Besu logs to Splunk
 
 Splunk can aggregate multiple logs in one place and run complex queries without being connected to the machine running Besu to read the standard output.
 
-Options for running Splunk and Besu are:
-
-- [Developer Quickstart with Splunk](#developer-quickstart-with-splunk)
-- [Use Splunk Enterprise as a Docker container](#use-splunk-enterprise-as-a-docker-container)
-- [Run a Splunk Enterprise instance](#run-a-splunk-enterprise-instance)
-
-## Developer Quickstart with Splunk
-
-To view the Quickstart network logs in Splunk:
-
-1. [Start the Developer Quickstart with Besu](../../tutorials/quickstart.md), selecting Splunk monitoring.
-1. Open the [Splunk UI](http://localhost:8000).
+To use Splunk with Besu, run Splunk Enterprise [as a Docker container](#use-splunk-enterprise-as-a-docker-container)
+or [as its own instance](#run-a-splunk-enterprise-instance).
 
 ## Use Splunk Enterprise as a Docker container
 
@@ -90,7 +80,7 @@ If running [Besu as a Docker container](../../get-started/install/run-docker-ima
     --network=dev \
     --logging=trace
     ```
-    
+
     The environment variables specified send the Besu logs to Splunk. Only `LOGGER`, `SPLUNK_URL`, `SPLUNK_TOKEN` and `SPLUNK_SKIPTLSVERIFY` are required in this example. The complete list of options is in the [Splunk options reference table](#splunk-options-reference).
 
 4.  In the Splunk Web interface, navigate to the [search page](http://localhost:8080/en-US/app/search/search). Type `index="besu"` in the search field. Log events sent by Besu are displayed.

--- a/docs/private-networks/tutorials/ethash.md
+++ b/docs/private-networks/tutorials/ethash.md
@@ -214,7 +214,7 @@ The result confirms Node-1 (the node running the JSON-RPC service) has two peers
 
 ## Next steps
 
-Import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](quickstart.md#create-a-transaction-using-metamask).
+Import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](quickstart.md#6-send-a-transaction-with-metamask).
 
 :::info
 

--- a/docs/private-networks/tutorials/ibft/index.md
+++ b/docs/private-networks/tutorials/ibft/index.md
@@ -368,7 +368,7 @@ This tutorial configures a private network using IBFT 2.0 for educational purpos
 
 :::
 
-Import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](../quickstart.md#create-a-transaction-using-metamask).
+Import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](../quickstart.md#6-send-a-transaction-with-metamask).
 
 :::info
 

--- a/docs/private-networks/tutorials/permissioning/index.md
+++ b/docs/private-networks/tutorials/permissioning/index.md
@@ -536,4 +536,4 @@ To restart the permissioned network in the future, start from [step 7](#7-start-
 <!-- Links -->
 
 [IBFT 2.0 proof of authority consensus protocol]: ../../how-to/configure/consensus/ibft.md
-[Quickstart tutorial]: ../quickstart.md#create-a-transaction-using-metamask
+[Quickstart tutorial]: ../quickstart.md#6-send-a-transaction-with-metamask

--- a/docs/private-networks/tutorials/qbft.md
+++ b/docs/private-networks/tutorials/qbft.md
@@ -259,7 +259,6 @@ besu --data-path=data --genesis-file=../genesis.json --bootnodes=<Node-1 Enode U
 
 <TabItem value="Windows" label="Windows">
 
-
 ```bash
 besu --data-path=data --genesis-file=..\genesis.json --bootnodes=<Node-1 Enode URL> --p2p-port=30305 --rpc-http-enabled --rpc-http-api=ETH,NET,QBFT --host-allowlist="*" --rpc-http-cors-origins="all" --rpc-http-port=8547 --profile=ENTERPRISE
 ```
@@ -363,7 +362,7 @@ If a new key was created, the validator key specified in the configuration does 
 
 ## Next steps
 
-Use the [QBFT API](../reference/api.md#qbft-methods) to remove or add validators, or import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](quickstart.md#create-a-transaction-using-metamask).
+Use the [QBFT API](../reference/api.md#qbft-methods) to remove or add validators, or import accounts to MetaMask and send transactions as described in the [Quickstart tutorial](quickstart.md#6-send-a-transaction-with-metamask).
 
 :::note
 

--- a/docs/private-networks/tutorials/quickstart.md
+++ b/docs/private-networks/tutorials/quickstart.md
@@ -43,7 +43,8 @@ You can use Docker Desktop or Docker Engine with the Compose plugin in the WSL2 
 
 ### 1. Generate the private network files
 
-Run the Developer Quickstart:
+Run the Developer Quickstart.
+The quickstart generates a folder (`./besu-test-network` by default) with the Docker Compose files, scripts, and Besu configuration in it.
 
 ```bash
 npx @consensys-software/besu-dev-quickstart
@@ -63,8 +64,6 @@ To skip the prompts, run:
 ```bash
 npx @consensys-software/besu-dev-quickstart --networkType private --outputPath ./besu-test-network --otel false --chainlens true
 ```
-
-The command creates the Docker Compose files, scripts, and Besu configuration in `besu-test-network`.
 
 ### 2. Start the network
 

--- a/docs/private-networks/tutorials/quickstart.md
+++ b/docs/private-networks/tutorials/quickstart.md
@@ -1,20 +1,18 @@
 ---
-title: Quorum Developer Quickstart
+title: Developer Quickstart
 sidebar_position: 1
 description: Rapidly generate a local blockchain network using the Quickstart.
+toc_max_heading_level: 3
 ---
 
 import TestAccounts from '../../global/test_accounts.md';
 
 import Postman from '../../global/postman.md';
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Developer Quickstart
 
-The Quorum Developer Quickstart uses the Besu Docker image to run a private [IBFT 2.0](../how-to/configure/consensus/ibft.md) 
-network of Besu nodes managed by Docker Compose.
+The Besu Developer Quickstart generates a local private [QBFT](../how-to/configure/consensus/qbft.md) network of Besu nodes managed by Docker Compose.
+Use this tutorial to create a development network, send JSON-RPC requests, view blocks and transactions, monitor nodes, and test a transaction from MetaMask.
 
 :::caution
 
@@ -23,87 +21,90 @@ networks.
 
 :::
 
-The stack provided includes optional components and apps to enable you to immediately use your private network in a realistic 
-way.
+The generated private network includes four validators, one non-validator RPC node, and monitoring services.
+You can optionally enable Chainlens Explorer and OpenTelemetry (OTel) when you generate the network.
 
 ## Prerequisites
 
-- One of the following operating systems:
-  - Linux on x86_64 architecture
-  - macOS on an Intel processor (M1 processor not supported yet)
-  - Windows 64-bit edition, with:
-    - Windows Subsystem for Linux 2
-    - Docker desktop configured to use the WSL2-based engine
-- [Docker and Docker Compose](https://docs.docker.com/compose/install/)
-- [Node.js](https://nodejs.org/en/download/) version 12 or higher (while maintaining Hardhat compatibility)
-- [Hardhat](https://hardhat.org/hardhat-runner/docs/getting-started#overview)
-- [cURL command line](https://curl.haxx.se/download.html)
+- [Docker and Docker Compose](https://docs.docker.com/compose/install/) v2 or later
+- [Node.js](https://nodejs.org/en/download/) or [Yarn](https://yarnpkg.com/cli/node)
+- [curl](https://curl.haxx.se/download.html)
 - [MetaMask](https://metamask.io/)
 
 :::info
 
-Allow Docker up to 4G of memory. Refer to the **Resources** section in [Docker for Mac](https://docs.docker.com/docker-for-mac/) 
-and [Docker Desktop](https://docs.docker.com/docker-for-windows/) for details.
+Allow Docker to use up to 6 GB of memory for the private network.
+On Windows, use Windows 11 with WSL2 kernel 6.6 or later.
+You can use Docker Desktop or Docker Engine with the Compose plugin in the WSL2 environment.
 
 :::
 
-## Generate the tutorial blockchain configuration files
+## Steps
 
-To create the tutorial `docker-compose` files and artifacts, run:
+### 1. Generate the private network files
+
+Run the Developer Quickstart:
 
 ```bash
-npx quorum-dev-quickstart
+npx @consensys-software/besu-dev-quickstart
 ```
 
-Follow the prompts displayed to run Besu and [logging with ELK](../how-to/monitor/elastic-stack.md). Enter `n` for Codefi 
-Orchestrate.
+When prompted, select the following options:
 
-## Start the network
+| Prompt                               | Selection             |
+| ------------------------------------ | --------------------- |
+| Network type                         | **Private**           |
+| Add OTel Collector spans to Grafana? | **N**                 |
+| Enable Chainlens Explorer?           | **Y**                 |
+| Config files directory               | `./besu-test-network` |
 
-To start the network, go to the installation directory (`quorum-test-network` if you used the default value) and run:
+To skip the prompts, run:
 
 ```bash
+npx @consensys-software/besu-dev-quickstart --networkType private --outputPath ./besu-test-network --otel false --chainlens true
+```
+
+The command creates the Docker Compose files, scripts, and Besu configuration in `besu-test-network`.
+
+### 2. Start the network
+
+Go to the generated directory and start the containers:
+
+```bash
+cd besu-test-network
 ./run.sh
 ```
 
-The script builds the Docker images, and runs the Docker containers.
+The script builds the Docker images and starts the network.
+The private network contains four QBFT validators named `validator1` through `validator4`, and one non-validator node named `rpcnode`.
 
-Four Besu IBFT 2.0 validator nodes and a non-validator node are created to simulate a base network.
-
-When execution is successfully finished, the process lists the available services:
+When startup finishes, the script lists the available endpoints:
 
 ```log title="Services list"
 *************************************
-Quorum Dev Quickstart
+Besu Dev Quickstart
 *************************************
 ----------------------------------
 List endpoints and services
 ----------------------------------
-JSON-RPC HTTP service endpoint      : http://localhost:8545
-JSON-RPC WebSocket service endpoint : ws://localhost:8546
-Web block explorer address          : http://localhost:25000/
-Prometheus address                  : http://localhost:9090/graph
-Grafana address                     : http://localhost:3000/d/XE4V0WGZz/besu-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All
-Kibana logs address                 : http://localhost:5601/app/kibana#/discover
-Collated logs using Grafana Loki    : http://localhost:3000/d/Ak6eXLsPxFemKYKEXfcH/quorum-logs-loki?orgId=1&var-app=besu&var-search=
+JSON-RPC HTTP service endpoint        : http://localhost:8545
+JSON-RPC WebSocket service endpoint   : ws://localhost:8546
+Prometheus address                    : http://localhost:9090/graph
+Grafana metrics                       : http://localhost:3000/d/XE4V0WGZz/besu-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All
+Grafana logs                          : http://localhost:3000/a/grafana-lokiexplore-app/explore
+Chainlens Explorer (if selected)      : http://localhost:8081/dashboard
 
 For more information on the endpoints and services, refer to README.md in the installation directory.
 ****************************************************************
 ```
-- Use the **JSON-RPC HTTP service endpoint** to access the RPC node service from your dapp or from cryptocurrency wallets such 
-as MetaMask.
-- Use the **JSON-RPC WebSocket service endpoint** to access the Web socket node service from your dapp.
-- Use the **Web block explorer address** to display the [block explorer Web application](http://localhost:25000).
-- Use the **Prometheus address** to access the [Prometheus dashboard](http://localhost:9090/graph). 
-[Read more about metrics](../../public-networks/how-to/monitor/metrics.md).
-- Use the **Grafana address** to access the 
-[Grafana dashboard](http://localhost:3000/d/XE4V0WGZz/besu-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All). 
-[Read more about metrics](../../public-networks/how-to/monitor/metrics.md).
-- Use the **Kibana logs address** to access the [logs in Kibana](http://localhost:5601/app/kibana#/discover). 
-[Read more about log management](../how-to/monitor/elastic-stack.md).
-- Use the **Grafana Loki logs address** to access the 
-[logs in Grafana](http://localhost:3000/d/Ak6eXLsPxFemKYKEXfcH/quorum-logs-loki?orgId=1&var-app=besu&var-search=). 
-[Read more about log management](../how-to/monitor/loki.md).
+
+Use the endpoints as follows:
+
+- Use the JSON-RPC HTTP endpoint to send requests to `rpcnode`.
+- Use the JSON-RPC WebSocket endpoint for WebSocket subscriptions.
+- Use Prometheus and Grafana to monitor node metrics.
+- Use Grafana logs to view Besu logs in Loki.
+- Use Chainlens Explorer to inspect blocks and transactions if you enabled it.
 
 To display the list of endpoints again, run:
 
@@ -111,28 +112,14 @@ To display the list of endpoints again, run:
 ./list.sh
 ```
 
-Congratulations, you are now running your private Besu network.
+You now have a running private Besu network.
 
-## Next steps
+### 3. Run JSON-RPC requests
 
-Next, consider interacting with your network using the development testnet stack.
+Send JSON-RPC requests to `http://localhost:8545`.
+You can also use `ws://localhost:8546` for WebSocket connections.
 
-### Run JSON-RPC requests
-
-You can run JSON-RPC requests on:
-
-- HTTP with `http://localhost:8545`.
-- WebSockets with `ws://localhost:8546`.
-
-#### Run with `cURL`
-
-This tutorial uses [cURL](https://curl.haxx.se/download.html) to send JSON-RPC requests over HTTP.
-
-#### Run with Postman
-
-You can also run all the requests with the Besu Postman collection.
-
-<Postman />
+This tutorial uses [curl](https://curl.haxx.se/download.html) to send JSON-RPC requests over HTTP.
 
 #### Request the node version
 
@@ -144,50 +131,27 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],
 
 The result displays the client version of the running node:
 
-<Tabs>
-
-<TabItem value="Result example" label="Result example" default>
-
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "besu/v21.1.2/linux-x86_64/oracle_openjdk-java-11"
+  "result": "besu/v26.2.0/linux-aarch_64/openjdk-java-21"
 }
 ```
 
-</TabItem>
-
-<TabItem value="Result explanation" label="Result explanation">
-
-- `"jsonrpc" : "2.0"` indicates that the JSON-RPC 2.0 spec format is used.
-- `"id" : 1` is the request identifier used to match the request and the response. This tutorial always uses 1.
-- `"result"` contains the running Besu information:
-  - `v21.1.2` is the running Besu version number. This may be different when you run this tutorial.
-  - `linux-x86_64` is the architecture used to build this version.
-  - `oracle_openjdk-java-11` is the JVM type and version used to build this version. This may be different when you run this 
-  tutorial.
-
-</TabItem>
-
-</Tabs>
-
-Successfully calling this method shows that you can connect to the nodes using JSON-RPC over HTTP.
-
-From here, you can walk through more interesting requests demonstrated in the rest of this section, or skip ahead to 
-[Create a transaction using MetaMask](#create-a-transaction-using-metamask).
+The exact version, architecture, and Java runtime can differ depending on the Besu image used by your generated network.
+Successfully calling this method shows that you can connect to the network using JSON-RPC over HTTP.
 
 #### Count the peers
 
 Peers are the other nodes connected to the node receiving the JSON-RPC request.
-
 Poll the peer count using [`net_peerCount`](../../public-networks/reference/api/index.md#net_peercount):
 
 ```bash
 curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' http://localhost:8545/ -H "Content-Type: application/json"
 ```
 
-The result indicates that there are four peers (the validators):
+The result indicates that `rpcnode` has four peers:
 
 ```json
 {
@@ -199,14 +163,13 @@ The result indicates that there are four peers (the validators):
 
 #### Request the most recent block number
 
-Call [`eth_blockNumber`](../../public-networks/reference/api/index.md#eth_blocknumber) to retrieve the number of the 
-most recently synchronized block:
+Call [`eth_blockNumber`](../../public-networks/reference/api/index.md#eth_blocknumber) to retrieve the highest block number on `rpcnode`:
 
 ```bash
 curl -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://localhost:8545/ -H "Content-Type: application/json"
 ```
 
-The result indicates the highest block number synchronized on this node.
+The result indicates the highest block number synchronized on this node:
 
 ```json
 {
@@ -216,568 +179,186 @@ The result indicates the highest block number synchronized on this node.
 }
 ```
 
-Here the hexadecimal value `0x2a` translates to decimal as `42`, the number of blocks received by the node so far, 
-about two minutes after the new network started.
+The hexadecimal value `0x2a` translates to `42`, the number of blocks received by the node so far.
 
-### Use a block explorer
+### 4. View the network in Chainlens
 
-You can [use Chainlens Blockchain Explorer](../how-to/monitor/chainlens.md) to analyze block
-information, contract metadata, transaction searches, and more.
+If you enabled Chainlens when generating the network, open `http://localhost:8081/dashboard` in your browser.
 
-:::note
-In production networks, you must [secure access](../../public-networks/how-to/use-besu-api/authenticate.md)
-to RPC nodes.
-:::
+Chainlens connects to `rpcnode` and displays network activity, blocks, and transactions.
+If the dashboard is empty at first, wait for the ingestion service to index the latest blocks, then refresh the page.
 
-Clone the [Chainlens GitHub repository](https://github.com/web3labs/chainlens-free):
+To add Chainlens after generating the network, generate a new quickstart directory with `--chainlens true`.
+The Developer Quickstart adds the Chainlens services to the generated Docker Compose file at generation time.
 
-```bash
-git clone https://github.com/web3labs/chainlens-free
-```
+### 5. Monitor nodes with Prometheus, Grafana, and Loki
 
-From the `docker-compose` directory, run the following command:
+The Developer Quickstart starts Prometheus, Grafana, Loki, and Grafana Alloy with the private network.
+Use these services to inspect node metrics and logs.
 
-```bash
-cd docker-compose
-NODE_ENDPOINT=member1besu PORT=26000 docker-compose -f docker-compose.yml -f chainlens-extensions/docker-compose-quorum-dev-quickstart.yml up
-```
+- Open `http://localhost:9090/graph` to query metrics in Prometheus.
+- Open the Grafana metrics URL listed by `./list.sh` to view the Besu overview dashboard.
+- Open the Grafana logs URL listed by `./list.sh` to view logs from Loki.
 
-Open `http://localhost/` on your browser.
-You’ll see the new initialization page while it boots up.
-This may take 5–10 minutes for the all services to start and the ingestion sync to complete.
+If you generated the network with `--otel true`, the Developer Quickstart also includes an OTel Collector and Tempo.
+Use Grafana to inspect the additional tracing data.
 
-To stop all the services from running, run the following command from the `docker-compose` directory:
+Learn more about how to [monitor metrics](../../public-networks/how-to/monitor/metrics.md).
 
-```bash
-docker-compose down -v
-```
+### 6. Send a transaction with MetaMask
 
-### Monitor nodes with Prometheus and Grafana
+Connect MetaMask to the local JSON-RPC endpoint and send a transaction between the prefunded test accounts.
 
-The sample network also includes Prometheus and Grafana monitoring tools to let you visualize node health and usage. You 
-can directly access these tools from your browser at the addresses displayed in the endpoint list.
+#### Import test accounts
 
-- [Prometheus dashboard](http://localhost:9090/graph)
-- [Grafana dashboard](http://localhost:3000/d/XE4V0WGZz/besu-overview?orgId=1&refresh=10s&from=now-30m&to=now&var-system=All)
-- [Grafana Loki logs dashboard](http://localhost:3000/d/Ak6eXLsPxFemKYKEXfcH/quorum-logs-loki?orgId=1&var-app=quorum&var-search=)
+Import two of the following test accounts into MetaMask.
+These accounts are already funded in the generated genesis file.
 
-For more details on how to configure and use these tools for your own nodes, see the 
-[performance monitoring documentation](../../public-networks/how-to/monitor/metrics.md), 
-[Prometheus documentation](https://prometheus.io/docs/introduction/overview/) and 
-[Grafana documentation](https://grafana.com/docs/).
-
-![Grafana dashboard screenshot](../../assets/images/grafana.png)
-
-You can view collated logs via Grafana Loki:
-
-![Grafana Loki dashboard screenshot](../../assets/images/grafana_loki.png)
-
-### Public transactions
-
-#### Transact via smart contracts
-
-These examples use the [web3.js](https://www.npmjs.com/package/web3) library to make the API calls, using the `rpcnode`
-accessed on `http://localhost:8545`.
-
-<Tabs>
-
-<TabItem value="eth-transfer" label="Transfer ETH" default>
-
-Navigate to the `smart_contracts` directory and deploy the `eth_tx` transaction:
-
-```bash
-cd smart_contracts
-npm install --legacy-peer-deps
-node scripts/public/hre_eth_tx.js
-```
-
-The output is as follows:
-
-```bash
-Account A has balance of: 90000
-Account B has balance of: 0
-create and sign the txn
-sending the txn
-tx transactionHash: 0x8b9d247900f2b50a8dded3c0d73ee29f04487a268714ec4ebddf268e73080f98
-Account A has an updated balance of: 89999.999999999999999744
-Account B has an updated balance of: 0.000000000000000256
-```
-
-</TabItem>
-
-<TabItem value="simple-storage" label="Get/set storage">
-
-Navigate to the `smart_contracts` directory and deploy the public transaction:
-
-```bash
-cd smart_contracts
-npm install --legacy-peer-deps
-node scripts/public/hre_1559_public_tx.js
-# or via ethers
-node scripts/public/hre_public_tx.js
-```
-
-This deploys the contract and sends an arbitrary value (`47`) from `Member1` to `Member3`. The script then performs:
-
-1. A read operation on the contract using the `get` function and the contract's ABI, at the specified address.
-1. A write operation using the `set` function and the contract's ABI, at the address and sets the value to `123`.
-1. A read operation on all events emitted.
-
-The script output is as follows:
-
-```bash
-{
-  address: '0x2b224e70f606267586616586850aC6f4Ae971eCb',
-  privateKey: '0xb3f2ab4d7bb07a4168432fb572ceb57fd9b842ed8dc41256255db6ff95784000',
-  signTransaction: [Function: signTransaction],
-  sign: [Function: sign],
-  encrypt: [Function: encrypt]
-}
-create and sign the txn
-sending the txn
-tx transactionHash: 0x423d56f958a316d2691e05e158c6a3f37004c27a1ec9697cf9fed2a5c2ae2c2b
-tx contractAddress: 0xB9A44d3BeF64ABfA1485215736B61880eDe630D9
-Contract deployed at address: 0xB9A44d3BeF64ABfA1485215736B61880eDe630D9
-Use the smart contracts 'get' function to read the contract's constructor initialized value .. 
-Obtained value at deployed contract is: 47
-Use the smart contracts 'set' function to update that value to 123 .. 
-sending the txn
-tx transactionHash: 0xab460da2544687c5fae4089d01b14bbb9bea765449e1fd2c30b30e1761481344
-tx contractAddress: null
-Verify the updated value that was set .. 
-Obtained value at deployed contract is: 123
-Obtained all value events from deployed contract : [47,123]
-```
-
-</TabItem>
-<TabItem value="counter" label="Increment counter">
-
-The script `hre_1559_public_tx.js` deploys a **Counter** contract. You can read its value and 
-send increment transactions using a small Node script.
-
-1. Ensure the network is running. Save the following as `increment_counter.js` in your `quorum-test-network` folder.
-
-```js title="increment_counter.js"
-#!/usr/bin/env node
-/**
- * Read Counter.getCount() (no tx) and optionally call incrementCounter() (signed tx).
- * Usage: node increment_counter.js [read|increment]
- * Override: COUNTER_ADDRESS=0x... RPC_URL=... PRIVATE_KEY=0x... node increment_counter.js [read|increment]
- */
-const CONTRACT_ADDRESS = process.env.COUNTER_ADDRESS || "0x49f8866d90ffDa8B12AC5677966e963acEc6d80E";
-const RPC_URL = process.env.RPC_URL || "http://127.0.0.1:8545";
-const PRIVATE_KEY = process.env.PRIVATE_KEY || "0x60bbe10a196a4e71451c0f6e9ec9beab454c2a5ac0542aa5b8b733ff5719fec3";
-
-const COUNTER_ABI = [
-  { inputs: [], name: "getCount", outputs: [{ internalType: "int256", name: "", type: "int256" }], stateMutability: "view", type: "function" },
-  { inputs: [], name: "incrementCounter", outputs: [], stateMutability: "nonpayable", type: "function" },
-  { inputs: [], name: "decrementCounter", outputs: [], stateMutability: "nonpayable", type: "function" },
-];
-
-async function main() {
-  const ethers = await import("ethers");
-  const provider = new ethers.JsonRpcProvider(RPC_URL);
-  const contract = new ethers.Contract(CONTRACT_ADDRESS, COUNTER_ABI, provider);
-  const action = process.argv[2] || "read";
-
-  if (action === "read") {
-    const count = await contract.getCount();
-    console.log("Counter.getCount() (no tx):", count.toString());
-    return;
-  }
-  if (action === "increment") {
-    const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
-    const contractWithSigner = contract.connect(wallet);
-    const tx = await contractWithSigner.incrementCounter();
-    console.log("Tx hash:", tx.hash);
-    await tx.wait();
-    const count = await contract.getCount();
-    console.log("Counter after increment:", count.toString());
-    return;
-  }
-  console.log('Usage: node increment_counter.js [read|increment]');
-}
-main().catch((err) => { console.error(err); process.exit(1); });
-```
-
-2. Ensure that Ethers is available from the `smart_contracts` folder with `npm install ethers`.
-
-3. From the `quorum-test-network` folder run:
-
-```bash
-cd smart_contracts
-node ../increment_counter.js read
-node ../increment_counter.js increment
-```
-
-- `read` — calls `getCount()` only (no transaction, no signing).
-- `increment` — sends an `incrementCounter()` transaction (signed with the script's built-in key).
-
-:::tip
-
-The default contract address is the Counter deployed by `hre_1559_public_tx.js`. To use a different deployment, 
-set `COUNTER_ADDRESS` when running the script:
-
-```bash
-COUNTER_ADDRESS=0xYourCounterAddress node ../increment_counter.js read
-```
-:::
-
-</TabItem>
-</Tabs>
-
-#### Transact via MetaMask
-
-##### Prerequisites
-
-- Browser with MetaMask extension
-
-You can use [MetaMask](https://metamask.io/) to send a transaction on your private network.
-
-1. Open MetaMask and connect it to your private network RPC endpoint by selecting `Localhost 8545` in the network list.
-1. Choose one of the following test accounts and 
-[import it into MetaMask](https://support.metamask.io/start/use-an-existing-wallet/#import-using-a-private-key).
- by copying the corresponding private key:
 <TestAccounts />
 
-:::note
+#### Add the network
 
-Besu doesn't incorporate [account management](../../public-networks/how-to/send-transactions.md). To create your own account, 
-you have to use a third-party tool, such as MetaMask.
+In MetaMask, add a custom network with the following values:
 
-:::
+| Field           | Value                   |
+| --------------- | ----------------------- |
+| Network name    | `Besu Dev Quickstart`   |
+| RPC URL         | `http://localhost:8545` |
+| Chain ID        | `1337`                  |
+| Currency symbol | `ETH`                   |
 
-1.  After importing an existing test account, [create another test account from scratch] to use as the recipient for a test 
-Ether transaction.
+#### Send the transaction
 
-1.  In MetaMask, select the new test account and 
-[copy its address](https://metamask.zendesk.com/hc/en-us/articles/360015289512-How-to-copy-your-MetaMask-Account-Public-Address).
+From one imported test account, send a small amount of ETH to another imported test account.
+The private network has zero gas price configured, so the transaction doesn't require a gas fee.
 
-1.  In the [Block Explorer](http://localhost:25000), search for the new test account by selecting the :mag: and pasting the test 
-account address into the search box.
+After MetaMask confirms the transaction, copy the transaction hash.
+If Chainlens is enabled, search for the transaction hash in `http://localhost:8081/dashboard`.
 
-    The new test account displays with a zero balance.
+### 7. Stop and restart the network
 
-1.  [Send test Ether](https://metamask.zendesk.com/hc/en-us/articles/360015488931-How-to-send-ETH-and-ERC-20-tokens-from-your-MetaMask-Wallet) from the first test account (containing test Ether) to the new test account (which has a zero balance).
-
-    :::tip
-
-    You can use a zero gas price here as this private test network is a [free gas network](../how-to/configure/free-gas.md), but 
-    the maximum amount of gas that can be used (the gas limit) for a value transaction must be at least 21000.
-
-    :::
-
-1.  Refresh the Block Explorer page in your browser displaying the target test account.
-
-    The updated balance reflects the transaction completed using MetaMask.
-
-#### Transact via a dapp
-
-##### Prerequisites
-
-- Browser with MetaMask extension
-
-Use the demo dapp, **QuorumToken** which uses an ERC-20 token deployed to the network.
-
-We'll use [Hardhat](https://www.npmjs.com/package/hardhat), [Ethers](https://www.npmjs.com/package/ethers) and 
-[MetaMask](https://metamask.io/) to interact with the network.
-
-The `dapps/quorumToken` directory is structured in this manner (only relevant paths shown):
-
-```bash
-quorumToken
-├── hardhat.config.ts       // hardhat network config
-├── contracts               // the QuorumToken.sol
-├── scripts                 // handy scripts eg: to deploy to a chain
-├── test                    // contract tests
-└── frontend                // dapp done in next.js
-  ├── public
-  ├── src
-  ├── styles
-  ├── tsconfig.json
-```
-
-##### Step 1: Deploy the contract 
-
-With the blockchain running, enter the `quorumToken` directory and run the following:
-
-```bash
-cd dapps/quorumToken
-# install dependencies
-npm install --legacy-peer-deps
-# compile the contract
-npm run compile
-npm run test
-# deploy the contract to the quickstart network
-npm run deploy-quorumtoken
-```
-The output is similar to the following:
-
-```bash
-# compile
-> quorumToken@1.0.0 compile
-> npx hardhat compile
-
-Generating typings for: 5 artifacts in dir: typechain-types for target: ethers-v6
-Successfully generated 24 typings!
-Compiled 5 Solidity files successfully
-
-# test
-> quorumToken@1.0.0 test
-> npx hardhat test
-
-  QuorumToken
-    Deployment
-      ✔ Should have the correct initial supply (1075ms)
-      ✔ Should token transfer with correct balance (78ms)
-
-
-  2 passing (1s)
-
-# deploy
-Contract deploy at: 0x5FbDB2315678afecb367f032d93F642f64180aa3
-```
-This will deploy the contract to the network and return the address. **Save this address for step 3**.
-
-##### Step 2: Run the dapp
-
-The dapp runs a local website using Next.js, and uses the contract in the previous step deployed on the network. Install and run
-with:
-
-```bash
-cd frontend
-npm install --legacy-peer-deps
-npm run dev
-```
-This starts the dapp, binding it to port `3001` on your machine.
-
-```bash
-> webapp@0.1.0 dev
-> next dev -p 3001
-
-- ready started server on [::]:3001, url: http://localhost:3001
-- event compiled client and server successfully in 270 ms (18 modules)
-- wait compiling...
-- event compiled client and server successfully in 173 ms (18 modules)
-```
-
-##### Step 3: Connect to the dapp with MetaMask
-
-3.1 With MetaMask connected to `localhost` on port `8545`, 
-[import the deployer account](https://support.metamask.io/start/use-an-existing-wallet/#import-using-a-private-key) to 
-MetaMask using its private key.
-
-:::info
-
-To see the initial QuorumToken balance in the dapp, the MetaMask account must be the **deployer** account (the account used 
-when you ran `npm run deploy-quorumtoken`) in step 1. That deployer is the first account in the quickstart network config: 
-`networks.quickstart.accounts[0]` in `dapps/quorumToken/hardhat.config.ts`. 
-
-:::
-
-3.2 In the browser, open a new tab and navigate to [the QuorumToken dapp](http://localhost:3001).
-Follow the prompt to connect to MetaMask and input the address from step 1. For example, our contract above 
-deployed to `0x5FbDB2315678afecb367f032d93F642f64180aa3`. 
-
-:::tip
-
-Paste only the contract address following `0x` to avoid triggering the dapps error handling loop.
-
-:::
-
-The dapp will then read the balance of the ERC-20 token. You can now send funds
-to another address (any of the other test accounts) on the network, and MetaMask will prompt you to sign the transaction
-and will send it.
-
-You can also search for the transaction and view its details in the [Block Explorer](http://localhost:25000/).
-
-![Dapp UI](../../assets/images/dapp-explorer-tx.png)
-
-The MetMask UI also keeps a record of the transaction.
-
-![Dapp UI](../../assets/images/dapp-metamask-tx.png)
-
-#### Deploy your own dapp
-
-You can deploy your own dapp to the Quorum Developer Quickstart by configuring your dapp to point to the Quickstart network.
-
-We recommend using [Hardhat](https://hardhat.org/hardhat-runner/docs/guides/project-setup), and you can use the sample
-`hardhat.config.js` to configure the `networks` object in the 
-[Hardhat configuration file](https://hardhat.org/hardhat-network/docs/reference#config)
-to specify which networks to connect to for deployments and testing. The Quickstart's RPC service endpoint is `http://localhost:8545`.
-
-For example, the following is the Hardhat configuration file for the QuorumToken dapp used in the Quickstart GoQuorum network:
-
-```js
-module.exports = {
-  networks: {
-    // in built test network to use when developing contracts
-    hardhat: {
-      chainId: 1337
-    },
-    quickstart: {
-      url: "http://127.0.0.1:8545",
-      chainId: 1337,
-      // test accounts only, all good ;)
-      accounts: [
-        "0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63",
-        "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
-        "0xae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"
-      ]
-    }
-  },  
-  defaultNetwork: "hardhat",
-  ...
-  ...
-```
-
-Deploy the contract using:
-
-```bash
-npx hardhat run ./scripts/deploy_quorumtoken.ts --network quickstart
-```
-
-### Stop and restart the private network without removing containers
-
-To shut down the private network without deleting the containers:
+Stop the containers without deleting the chain data:
 
 ```bash
 ./stop.sh
 ```
 
-This command stops the containers related to the services specified in the `docker-compose.yml` file.
-
-To restart the private network:
+Restart the containers with the existing data:
 
 ```bash
 ./resume.sh
 ```
 
-### Stop the private network and remove containers
+### 8. Remove the network
 
-To shut down the private network and delete all containers and images created from running the sample network and the Pet 
-Shop dapp:
+Stop the containers and remove the generated container volumes:
 
 ```bash
 ./remove.sh
 ```
 
-### Add a new node to the network
+The command doesn't delete the generated files in `besu-test-network`.
 
-New nodes joining an existing network require the following:
+### 9. Add a non-validator node
 
-- The same genesis file used by all other nodes on the running network.
-- A list of nodes to connect to; this is done by specifying [bootnodes], or by providing a list of [static nodes].
-- A node key pair and optionally an account. If the running network is using permissions, then you need to add the new node's 
-enode details to the [permissions file] used by existing nodes.
+You can add a non-validator Besu node to the private network by generating node keys, adding a Docker Compose service, and allowing the node in the network configuration.
+To add a validator instead, use the [QBFT validator voting process](../how-to/configure/consensus/qbft.md#add-and-remove-validators) after the node is running.
 
-The following steps describe the process to add a new node to the Developer Quickstart.
+#### Generate node keys
 
-#### 1. Create the node key files
-
-Create a node key pair and account for a new node by running the following script:
+From the `besu-test-network` directory, generate the node details:
 
 ```bash
-cd ./extra
-npm install --legacy-peer-deps
-node generate_node_keys.js --password "Password"
+cd extra
+npm install
+node generate_node_details.js --password "Password"
 ```
 
-:::note
+The script writes the following files:
 
-The `--password` parameter is optional.
+- `nodekey`
+- `nodekey.pub`
+- `address`
+- `accountKeystore`
+- `accountPrivateKey`
+- `accountPassword`
 
-:::
+Create a directory for the new node and copy the files:
 
-#### 2. Create new node directory
-
-Navigate to the directory where the configuration files for the network were created.
-
-:::note
-
-The directory was specified in an earlier step when running `npx quorum-dev-quickstart`. The default location is 
-`./quorum-test-network`.
-
-:::
-
-In the `config/nodes` directory, create a subdirectory for the new node (for example, `newnode`), and move the `nodekey`, 
-`nodekey.pub`, `address` and `accountkey` files from the previous step into this directory.
-
-#### 3. Update docker-compose
-
-Add an entry for the new node into the docker-compose file:
-
-```yaml
-newnode:
-  <<: *besu-def
-  container_name: newnode
-  volumes:
-    - public-keys:/opt/besu/public-keys/
-    - ./config/besu/:/config
-    - ./config/nodes/newnode:/opt/besu/keys
-    - ./logs/besu:/tmp/besu
-  depends_on:
-    - validator1
-  networks:
-    quorum-dev-quickstart:
-      ipv4_address: 172.16.239.41
+```bash
+cd ..
+mkdir -p config/nodes/node5
+cp extra/nodekey extra/nodekey.pub extra/accountKeystore extra/accountPassword config/nodes/node5/
 ```
 
-:::caution important
+#### Add the Docker Compose service
 
-Select an IP address and port map not being used for the other containers.
-Mount the newly created folder `./config/nodes/newnode` to the `/opt/besu/keys` directory of the new node, as seen
-in this example.
-
-:::
-
-#### 4. Update Prometheus configuration
-
-Update `prometheus.yml` in the `./config/prometheus/` directory to configure metrics to display in Grafana.
-
-Insert the following under `scrape_configs` section in the file. Change `job_name` and `targets` appropriately if you've 
-updated them.
+In `docker-compose.yml`, add a service for `node5`.
+Use an unused IP address in the `besu-dev-quickstart` subnet:
 
 ```yaml
-- job_name: newnode
-  scrape_interval: 15s
-  scrape_timeout: 10s
+  node5:
+    << : *besu-def
+    container_name: node5
+    environment:
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=node5,service.version=${BESU_VERSION:-latest}
+    volumes:
+      - ./config/besu/:/config
+      - ./config/nodes/node5:/opt/besu/keys
+      - ./logs/besu:/tmp/besu
+    depends_on:
+      - validator1
+    ports:
+      - 21005:8545/tcp
+      - 30303
+      - 9545
+    networks:
+      besu-dev-quickstart:
+        ipv4_address: 172.16.239.16
+```
+
+#### Allow and discover the node
+
+Create the enode URL for the new node using the contents of `config/nodes/node5/nodekey.pub`:
+
+```text
+enode://<nodekey.pub>@172.16.239.16:30303
+```
+
+Add the enode URL to `config/besu/permissions_config.toml`.
+Also add it to `config/besu/static-nodes.json` so existing nodes discover it when they restart.
+
+#### Add the node to Prometheus
+
+In `config/prometheus/prometheus.yml`, add a scrape job for `node5`:
+
+```yaml
+- job_name: "node5"
   metrics_path: /metrics
   scheme: http
   static_configs:
-    - targets: [newnode:9545]
+    - targets: [node5:9545]
 ```
 
-#### 5. Update files with the enode address
+#### Restart the network
 
-Add the new node's enode address to the [static nodes] file and [permissions file]. The enode uses the format 
-`enode://pubkey@ip_address:30303`. If the `nodekey.pub` is `4540ea...9c1d78` and the IP address is `172.16.239.41`, then the 
-enode address is `"enode://4540ea...9c1d78@172.16.239.41:30303"`, which must be added to both files.
+Restart the network for the updated Docker Compose and Besu configuration files to take effect:
 
-Alternatively, call the [`perm_addNodesToAllowlist`](../reference/api.md#perm_addnodestoallowlist) API method on existing 
-nodes to add the new node without restarting.
+```bash
+./stop.sh
+./resume.sh
+```
 
-:::note
+After the containers start, confirm that `node5` appears in Docker and that the peer count has increased:
 
-Calling the API method by itself only persists for as long as the nodes remain online and is lost on the next restart.
+```bash
+docker compose ps node5
+curl -X POST --data '{"jsonrpc":"2.0","method":"net_peerCount","params":[],"id":1}' http://localhost:8545/ -H "Content-Type: application/json"
+```
 
-On a live network, the new node must be added to the [permissions file] so that subsequent restarts of the nodes are aware 
-of the change.
+## Next steps
 
-:::
-
-#### 6. Start the network
-
-Once complete, start the network up with `./run.sh`. When using the smart contract you can either make changes via a 
-[dapp](https://github.com/ConsenSys/permissioning-smart-contracts) or via 
-[RPC API calls](../reference/api.md#perm_addnodestoallowlist).
-
-<!-- Links -->
-
-[bootnodes]: ../how-to/configure/bootnodes.md
-[permissions file]: ../how-to/use-local-permissioning.md
-[static nodes]: ../../public-networks/how-to/connect/static-nodes.md
-[allow list]: ../how-to/use-local-permissioning.md#node-allowlisting
-[Import one of the existing accounts above into MetaMask]: https://metamask.zendesk.com/hc/en-us/articles/360015489331-Importing-an-Account-New-UI-
-[create another test account from scratch]: https://metamask.zendesk.com/hc/en-us/articles/360015289452-Creating-Additional-MetaMask-Wallets-New-UI-
-
+- [Configure QBFT consensus](../how-to/configure/consensus/qbft.md).
+- [Configure local permissioning](../how-to/use-local-permissioning.md).
+- [Deploy and interact with smart contracts](./contracts/interact.md).
+- [Monitor Besu metrics](/public-networks/how-to/monitor/metrics).

--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -114,10 +114,5 @@ The [Besu Developer Quickstart](https://github.com/Consensys/besu-dev-quickstart
 
 <!-- Links -->
 
-<<<<<<< 1961-besu-dev-quickstart
-[default configuration]: https://github.com/hyperledger/besu/blob/750580dcca349d22d024cc14a8171b2fa74b505a/besu/src/main/resources/log4j2.xml
-[log rotation to restrict the size of the log files]: https://github.com/Consensys/besu-dev-quickstart/blob/master/files/common/config/besu/log-config.xml
-=======
 [default configuration]: https://github.com/besu-eth/besu/blob/750580dcca349d22d024cc14a8171b2fa74b505a/besu/src/main/resources/log4j2.xml
-[log rotation to restrict the size of the log files]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/besu/config/besu/log-config.xml
->>>>>>> main
+[log rotation to restrict the size of the log files]: https://github.com/Consensys/besu-dev-quickstart/blob/master/files/common/config/besu/log-config.xml

--- a/docs/public-networks/how-to/monitor/logging.md
+++ b/docs/public-networks/how-to/monitor/logging.md
@@ -13,7 +13,7 @@ Besu uses [Log4j 2](https://logging.apache.org/log4j/2.x/) for logging and provi
 - [Basic](#basic-logging) - Changes the log level.
 - [Advanced](#advanced-logging) - Configures the output and format of the logs.
 
-[Quorum Developer Quickstart](https://github.com/ConsenSys/quorum-dev-quickstart) provides an [example implementation using Elastic Stack](../../../private-networks/how-to/monitor/elastic-stack.md) for log management.
+[Besu Developer Quickstart](https://github.com/Consensys/besu-dev-quickstart) provides an example implementation using Grafana Alloy, Loki, and Grafana for log management.
 
 ## Basic logging
 
@@ -110,9 +110,9 @@ For example, the following Log4j 2 configuration enables logging of invalid tran
 
 ### Log rotation
 
-The [Quorum Developer Quickstart](https://github.com/ConsenSys/quorum-dev-quickstart) logging configuration defines a [log rotation to restrict the size of the log files].
+The [Besu Developer Quickstart](https://github.com/Consensys/besu-dev-quickstart) logging configuration defines a [log rotation to restrict the size of the log files].
 
 <!-- Links -->
 
 [default configuration]: https://github.com/hyperledger/besu/blob/750580dcca349d22d024cc14a8171b2fa74b505a/besu/src/main/resources/log4j2.xml
-[log rotation to restrict the size of the log files]: https://github.com/ConsenSys/quorum-dev-quickstart/blob/b72a0f64d685c851bf8be399a8e33bbdf0e09982/files/besu/config/besu/log-config.xml
+[log rotation to restrict the size of the log files]: https://github.com/Consensys/besu-dev-quickstart/blob/master/files/common/config/besu/log-config.xml

--- a/docs/public-networks/how-to/monitor/metrics.md
+++ b/docs/public-networks/how-to/monitor/metrics.md
@@ -210,4 +210,4 @@ You can enable metric categories using the
 
 <!-- Links -->
 
-[monitoring with Prometheus and Grafana configured]: ../../../private-networks/tutorials/quickstart.md#monitor-nodes-with-prometheus-and-grafana
+[monitoring with Prometheus and Grafana configured]: ../../../private-networks/tutorials/quickstart.md#5-monitor-nodes-with-prometheus-grafana-and-loki

--- a/docs/public-networks/how-to/monitor/understand-metrics.md
+++ b/docs/public-networks/how-to/monitor/understand-metrics.md
@@ -94,6 +94,6 @@ Block network takes between 13 and 16 seconds.
 
 <!--links-->
 
-[monitoring Besu with Prometheus and Grafana]: ../../../private-networks/tutorials/quickstart.md#monitor-nodes-with-prometheus-and-grafana
+[monitoring Besu with Prometheus and Grafana]: ../../../private-networks/tutorials/quickstart.md#5-monitor-nodes-with-prometheus-grafana-and-loki
 
 [^1]: A CPU-bound task means that the time required to execute the task is determined only by the CPU speed.


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

- Updates the private network quickstart tutorial to use Besu Dev Quickstart instead of deprecated Quorum Dev Quickstart.
- Refreshes setup, endpoints, monitoring, Chainlens, MetaMask, lifecycle, and add-node steps for the current Besu Dev Quickstart workflow.
- Removes obsolete Quorum-generated smart contract, dapp, privacy, ELK/Splunk, Blockscout, Tessera, and EthSigner content.

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #1961 

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-git-fork-alexandratran-1961-besu-d-f79907-hyperledger.vercel.app/private-networks/tutorials/quickstart
