### PR TITLE
Clarify object docs

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -4794,6 +4794,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockHashAnd
   "result": {
     "blockHash": "0xbf137c3a7a1ebdfac21252765e5d7f40d115c2757e4a4abee929be88c624fdb7",
     "blockNumber": "0x1442e",
+    "blockTimestamp": "0x561bc2e0",
     "chainId": 2018,
     "from": "0x70c9217d814985faef62b124420f8dfbddd96433",
     "gas": "0x3d090",
@@ -4911,6 +4912,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberA
   "result": {
     "blockHash": "0xbf137c3a7a1ebdfac21252765e5d7f40d115c2757e4a4abee929be88c624fdb7",
     "blockNumber": "0x1442e",
+    "blockTimestamp": "0x561bc2e0",
     "chainId": 2018,
     "from": "0x70c9217d814985faef62b124420f8dfbddd96433",
     "gas": "0x3d090",
@@ -5022,6 +5024,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","param
   "result": {
     "blockHash": "0x510efccf44a192e6e34bcb439a1947e24b86244280762cbb006858c237093fda",
     "blockNumber": "0x422",
+    "blockTimestamp": "0x561bc2e0",
     "chainId": 2018,
     "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
     "gas": "0x5208",

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -3668,7 +3668,7 @@ the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as desc
 
 #### Returns
 
-`result`: _object_ - [block object](objects.md#block-object), or `null` when there is no block.
+`result`: _array_ of _objects_ - list of [transaction receipt objects](objects.md#transaction-receipt-object), or `null` when there is no block.
 
 <Tabs>
 
@@ -3719,6 +3719,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockReceipts","params":[
           "transactionHash": "0x4a481e4649da999d92db0585c36cba94c18a33747e95dc235330e6c737c6f975",
           "transactionIndex": "0x0",
           "blockHash": "0x19514ce955c65e4dd2cd41f435a75a46a08535b8fc16bc660f8092b32590b182",
+          "blockTimestamp": "0x561bc2e0",
           "logIndex": "0x0",
           "removed": false
         }

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -36,7 +36,7 @@ The `block` field in [`debug_getBadBlocks`](index.md#debug_getbadblocks) results
 | `size` | Quantity, Integer | Size of block in bytes. |
 | `gasLimit` | Quantity | Maximum gas allowed in this block. |
 | `gasUsed` | Quantity | Total gas used by all transactions in this block. |
-| `timestamp` | Quantity | Hex-encoded Unix timestamp, in seconds, for block assembly. |
+| `timestamp` | Quantity | Hex-encoded Unix timestamp (in seconds) for block assembly. |
 | `transactions` | Array | Array of [transaction objects](#transaction-object), or 32 byte transaction hashes depending on the specified boolean parameter. |
 | `uncles` | Array | Array of uncle hashes. |
 | `baseFeePerGas` | Quantity | The block's [base fee per gas](../../concepts/transactions/types.md#eip1559-transactions). This field is empty for blocks created before [EIP-1559](https://github.com/ethereum/EIPs/blob/2d8a95e14e56de27c5465d93747b0006bd8ac47f/EIPS/eip-1559.md). |

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -15,7 +15,9 @@ This reference contains API objects that apply to both public and private networ
 
 ## Block object
 
-Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash), [`eth_getBlockByNumber`](index.md#eth_getblockbynumber), and [`eth_simulateV1`](index.md#eth_simulatev1).
+Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash), [`eth_getBlockByNumber`](index.md#eth_getblockbynumber), [`eth_getUncleByBlockHashAndIndex`](index.md#eth_getunclebyblockhashandindex), [`eth_getUncleByBlockNumberAndIndex`](index.md#eth_getunclebyblocknumberandindex), and [`eth_simulateV1`](index.md#eth_simulatev1).
+The `block` field in [`debug_getBadBlocks`](index.md#debug_getbadblocks) results is also a block object.
+Block objects include `timestamp`, not `blockTimestamp`.
 
 | Key | Type | Value |
 | --- | :-: | --- |
@@ -35,7 +37,7 @@ Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash), [`eth_getBlockB
 | `size` | Quantity, Integer | Size of block in bytes. |
 | `gasLimit` | Quantity | Maximum gas allowed in this block. |
 | `gasUsed` | Quantity | Total gas used by all transactions in this block. |
-| `timestamp` | Quantity | Unix timestamp (milliseconds) for block assembly. |
+| `timestamp` | Quantity | Hex-encoded Unix timestamp, in seconds, for block assembly. |
 | `transactions` | Array | Array of [transaction objects](#transaction-object), or 32 byte transaction hashes depending on the specified boolean parameter. |
 | `uncles` | Array | Array of uncle hashes. |
 | `baseFeePerGas` | Quantity | The block's [base fee per gas](../../concepts/transactions/types.md#eip1559-transactions). This field is empty for blocks created before [EIP-1559](https://github.com/ethereum/EIPs/blob/2d8a95e14e56de27c5465d93747b0006bd8ac47f/EIPS/eip-1559.md). |
@@ -259,7 +261,7 @@ All transaction call object parameters are optional.
 
 ## Transaction receipt object
 
-Returned by [`eth_getTransactionReceipt`](index.md#eth_gettransactionreceipt).
+Returned by [`eth_getTransactionReceipt`](index.md#eth_gettransactionreceipt) and [`eth_getBlockReceipts`](index.md#eth_getblockreceipts).
 
 | Key | Type | Value |
 | --- | :-: | --- |

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -216,7 +216,7 @@ Returned by [`eth_getTransactionByHash`](index.md#eth_gettransactionbyhash), [`e
 | `accessList` | Array | (Optional) List of addresses and storage keys the transaction plans to access. Used in [`ACCESS_LIST` transactions](../../concepts/transactions/types.md#access_list-transactions) and may be used in [`EIP1559` transactions](../../concepts/transactions/types.md#eip1559-transactions). |
 | `blockHash` | Data, 32&nbsp;bytes | Hash of the block containing this transaction. `null` when transaction is pending. |
 | `blockNumber` | Quantity | Block number of the block containing this transaction. `null` when transaction is pending. |
-| `blockTimestamp` | Quantity | Hex-encoded Unix timestamp, in seconds, of the block containing this transaction. `null` when transaction is pending. |
+| `blockTimestamp` | Quantity | Hex-encoded Unix timestamp (in seconds) of the block containing this transaction. `null` when transaction is pending. |
 | `chainId` | Quantity | [Chain ID](../../concepts/network-and-chain-id.md). |
 | `from` | Data, 20&nbsp;bytes | Address of the sender. |
 | `gas` | Quantity | Gas provided by the sender. |

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -17,7 +17,6 @@ This reference contains API objects that apply to both public and private networ
 
 Returned by [`eth_getBlockByHash`](index.md#eth_getblockbyhash), [`eth_getBlockByNumber`](index.md#eth_getblockbynumber), [`eth_getUncleByBlockHashAndIndex`](index.md#eth_getunclebyblockhashandindex), [`eth_getUncleByBlockNumberAndIndex`](index.md#eth_getunclebyblocknumberandindex), and [`eth_simulateV1`](index.md#eth_simulatev1).
 The `block` field in [`debug_getBadBlocks`](index.md#debug_getbadblocks) results is also a block object.
-Block objects include `timestamp`, not `blockTimestamp`.
 
 | Key | Type | Value |
 | --- | :-: | --- |

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -215,6 +215,7 @@ Returned by [`eth_getTransactionByHash`](index.md#eth_gettransactionbyhash), [`e
 | `accessList` | Array | (Optional) List of addresses and storage keys the transaction plans to access. Used in [`ACCESS_LIST` transactions](../../concepts/transactions/types.md#access_list-transactions) and may be used in [`EIP1559` transactions](../../concepts/transactions/types.md#eip1559-transactions). |
 | `blockHash` | Data, 32&nbsp;bytes | Hash of the block containing this transaction. `null` when transaction is pending. |
 | `blockNumber` | Quantity | Block number of the block containing this transaction. `null` when transaction is pending. |
+| `blockTimestamp` | Quantity | Hex-encoded Unix timestamp, in seconds, of the block containing this transaction. `null` when transaction is pending. |
 | `chainId` | Quantity | [Chain ID](../../concepts/network-and-chain-id.md). |
 | `from` | Data, 20&nbsp;bytes | Address of the sender. |
 | `gas` | Quantity | Gas provided by the sender. |


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

- Adds `blockTimestamp` to the `eth_getTransactionBy*` result examples and transaction object reference.
- Corrects `eth_getBlockReceipts` return docs to reference transaction receipt objects instead of block objects.
- Updates the `eth_getBlockReceipts` example log object to include `blockTimestamp`.
- Updates that block object `timestamp` is in seconds instead of milliseconds.

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #1990 
Fixes #1994 

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->
