### PR TITLE
Block number param is hex-only

### DIFF
--- a/docs/private-networks/reference/api.md
+++ b/docs/private-networks/reference/api.md
@@ -163,7 +163,7 @@ The proposer of the genesis block has address `0x0000000000000000000000000000000
 <TabItem value="curl HTTP" label="curl HTTP" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"ibft_getSignerMetrics","params":["1", "100"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+curl -X POST --data '{"jsonrpc":"2.0","method":"ibft_getSignerMetrics","params":["0x1", "0x64"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
 ```
 
 </TabItem>
@@ -171,7 +171,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"ibft_getSignerMetrics","params":
 <TabItem value="wscat WS" label="wscat WS">
 
 ```bash
-{"jsonrpc":"2.0","method":"ibft_getSignerMetrics","params":["1", "100"], "id":1}
+{"jsonrpc":"2.0","method":"ibft_getSignerMetrics","params":["0x1", "0x64"], "id":1}
 ```
 
 </TabItem>
@@ -856,7 +856,7 @@ The proposer of the genesis block has address `0x0000000000000000000000000000000
 <TabItem value="curl HTTP" label="curl HTTP" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"qbft_getSignerMetrics","params":["1", "100"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+curl -X POST --data '{"jsonrpc":"2.0","method":"qbft_getSignerMetrics","params":["0x1", "0x64"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
 ```
 
 </TabItem>
@@ -864,7 +864,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"qbft_getSignerMetrics","params":
 <TabItem value="wscat WS" label="wscat WS">
 
 ```bash
-{"jsonrpc":"2.0","method":"qbft_getSignerMetrics","params":["1", "100"], "id":1}
+{"jsonrpc":"2.0","method":"qbft_getSignerMetrics","params":["0x1", "0x64"], "id":1}
 ```
 
 </TabItem>

--- a/docs/public-networks/how-to/use-besu-api/json-rpc.md
+++ b/docs/public-networks/how-to/use-besu-api/json-rpc.md
@@ -314,7 +314,7 @@ have a block parameter.
 The block parameter can have one of the following values:
 
 - `blockNumber` : _quantity_ - The block number, specified in hexadecimal.
-  `0` represents the genesis block.
+  `0x0` represents the genesis block.
 - `blockHash` : _string_ or _object_ - 32-byte block hash or JSON object specifying the block hash.
   If using a JSON object, you can specify `requireCanonical` to indicate whether the block must be a
   canonical block.

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -282,7 +282,7 @@ You can skip a parameter by using an empty string, `""`. If you specify:
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"admin_logsRemoveCache","params":["1", "100"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+curl -X POST --data '{"jsonrpc":"2.0","method":"admin_logsRemoveCache","params":["0x1", "0x64"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
 ```
 
 </TabItem>
@@ -293,7 +293,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"admin_logsRemoveCache","params":
 {
   "jsonrpc": "2.0",
   "method": "admin_logsRemoveCache",
-  "params": ["1", "100"],
+  "params": ["0x1", "0x64"],
   "id": 1
 }
 ```
@@ -4886,7 +4886,7 @@ Returns transaction information for the specified block number and transaction i
 <TabItem value="curl HTTP" label="curl HTTP" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberAndIndex","params":["82990", "0x2"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberAndIndex","params":["0x1442e", "0x2"], "id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
 ```
 
 </TabItem>
@@ -4897,7 +4897,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberA
 {
   "jsonrpc": "2.0",
   "method": "eth_getTransactionByBlockNumberAndIndex",
-  "params": ["82990", "0x2"],
+  "params": ["0x1442e", "0x2"],
   "id": 1
 }
 ```


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

Audit RPC examples that use the block parameter and update block numbers to hex. Block parameter description already specifies hex - updated genesis block example.

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #2013 

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-i759ichg5-hyperledger.vercel.app/public-networks/how-to/use-besu-api/json-rpc#block-parameter
