### PR TITLE
docs(debug): document enableReturnData param and returnData structure…

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -1543,6 +1543,8 @@ Use [`debug_standardTraceBadBlockToFile`](#debug_standardtracebadblocktofile) to
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+
 #### Returns
 
 `result`: _string_ - location of the generated trace files
@@ -1614,6 +1616,8 @@ Use [`debug_standardTraceBlockToFile`](#debug_standardtraceblocktofile) to view 
   - `disableStorage`: _boolean_ - omit storage from the trace; defaults to `true`
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
+
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
 
 #### Returns
 
@@ -1756,6 +1760,8 @@ Reruns the transaction with the same state as when the transaction executed.
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+
 #### Returns
 
 `result`: _object_ - [trace object](objects.md#trace-object)
@@ -1765,7 +1771,7 @@ Reruns the transaction with the same state as when the transaction executed.
 <TabItem value="curl HTTP request" label="curl HTTP request" default>
 
 ```bash
-curl -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x2cc6c94c21685b7e0f8ddabf277a5ccf98db157c62619cde8baea696a74ed18e",{"disableStorage":true}],"id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+curl -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x2cc6c94c21685b7e0f8ddabf277a5ccf98db157c62619cde8baea696a74ed18e",{"disableStorage":true,"enableReturnData":true}],"id":1}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
 ```
 
 </TabItem>
@@ -1778,7 +1784,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params"
   "method": "debug_traceTransaction",
   "params": [
     "0x2cc6c94c21685b7e0f8ddabf277a5ccf98db157c62619cde8baea696a74ed18e",
-    { "disableStorage": true }
+    { "disableStorage": true, "enableReturnData": true }
   ],
   "id": 1
 }
@@ -1799,11 +1805,12 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params"
     "structLogs": [
       {
         "pc": 0,
-        "op": "STOP",
+        "op": "RETURN",
         "gas": 0,
         "gasCost": 0,
         "depth": 1,
-        "stack": []
+        "stack": [],
+        "returnData": "0x0000000000000000000000000000000000000000000000000000000000000001"
       }
     ]
   }
@@ -1834,6 +1841,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
   - `disableStack` : _boolean_ - `true` disables stack capture. The default is `false`.
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
+
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
 
 #### Returns
 
@@ -1912,6 +1921,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
   - `disableStack` : _boolean_ - `true` disables stack capture. The default is `false`.
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
+
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
 
 #### Returns
 
@@ -1998,6 +2009,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
   - `disableStack` : _boolean_ - `true` disables stack capture. The default is `false`.
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
+
+  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
 
 #### Returns
 
@@ -2091,6 +2104,8 @@ temporary state changes without affecting the actual blockchain state.
     The default is `false`.
 
   - `opcodes`: _array_ of _strings_ - (optional) list of opcode names to trace; if omitted or empty, all opcodes are traced
+
+  - `enableReturnData`: _boolean_ - (optional) `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
 
   - `stateOverrides`: _object_ - (optional) [address-to-state mapping](./objects.md#state-override-object)
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -1543,7 +1543,7 @@ Use [`debug_standardTraceBadBlockToFile`](#debug_standardtracebadblocktofile) to
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -1617,7 +1617,7 @@ Use [`debug_standardTraceBlockToFile`](#debug_standardtraceblocktofile) to view 
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -1760,7 +1760,7 @@ Reruns the transaction with the same state as when the transaction executed.
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -1804,10 +1804,10 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"debug_traceTransaction","params"
     "returnValue": "",
     "structLogs": [
       {
-        "pc": 0,
-        "op": "RETURN",
-        "gas": 0,
-        "gasCost": 0,
+        "pc": 100,
+        "op": "STATICCALL",
+        "gas": 78000,
+        "gasCost": 500,
         "depth": 1,
         "stack": [],
         "returnData": "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -1842,7 +1842,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -1922,7 +1922,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -2010,7 +2010,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `opcodes`: _array_ of _strings_ - list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - `true` enables return data capture. The default is `false`.
 
 #### Returns
 
@@ -2105,7 +2105,7 @@ temporary state changes without affecting the actual blockchain state.
 
   - `opcodes`: _array_ of _strings_ - (optional) list of opcode names to trace; if omitted or empty, all opcodes are traced
 
-  - `enableReturnData`: _boolean_ - (optional) `true` captures EVM return data per opcode and includes `returnData` in each applicable structured log entry. The default is `false`. The field is omitted when not enabled or when return data is empty.
+  - `enableReturnData`: _boolean_ - (optional) `true` enables return data capture. The default is `false`.
 
   - `stateOverrides`: _object_ - (optional) [address-to-state mapping](./objects.md#state-override-object)
 

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -182,6 +182,7 @@ Log information returned as part of the [Trace object](#trace-object).
 | `stack` | Array of 32&nbsp;byte arrays | EVM execution stack before executing current operation. |
 | `memory` | Array of 32&nbsp;byte arrays | Memory space of the contract before executing current operation. |
 | `storage` | Object | Storage entries changed by the current transaction. |
+| `returnData` | Data | (Optional) EVM return data produced by the current opcode, as a `0x`-prefixed hex string. Present only when `enableReturnData` is `true` in the request options and the opcode produces non-empty return data. Omitted otherwise. |
 
 ## Trace object
 

--- a/docs/public-networks/reference/api/objects.md
+++ b/docs/public-networks/reference/api/objects.md
@@ -182,7 +182,7 @@ Log information returned as part of the [Trace object](#trace-object).
 | `stack` | Array of 32&nbsp;byte arrays | EVM execution stack before executing current operation. |
 | `memory` | Array of 32&nbsp;byte arrays | Memory space of the contract before executing current operation. |
 | `storage` | Object | Storage entries changed by the current transaction. |
-| `returnData` | Data | (Optional) EVM return data produced by the current opcode, as a `0x`-prefixed hex string. Present only when `enableReturnData` is `true` in the request options and the opcode produces non-empty return data. Omitted otherwise. |
+| `returnData` | Data | EVM return data produced by the current opcode, as a hex string. |
 
 ## Trace object
 


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

Add the `enableReturnData` parameter to TransactionTraceParams for all seven debug trace methods:
- debug_traceTransaction
- debug_traceBlock
- debug_traceBlockByHash
- debug_traceBlockByNumber
- debug_traceCall
- debug_standardTraceBlockToFile
- debug_standardTraceBadBlockToFile.

Also add `returnData` to the structured log object reference, and update the debug_traceTransaction example to demonstrate the option.

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #2015 

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-600aelr40-hyperledger.vercel.app/public-networks/reference/api#debug_tracetransaction
