### PR TITLE
Add eth_getTransactionBySenderAndNonce and --tx-sender-nonce-index-enabled docs

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -5109,6 +5109,89 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{transaction
 
 </Tabs>
 
+### `eth_getTransactionBySenderAndNonce`
+
+Returns transaction information for the given sender address and nonce.
+
+:::note
+
+This method requires the sender and nonce index to look up mined transactions. The index is
+enabled by default. You can disable it using the
+[`--tx-sender-nonce-index-enabled`](../cli/options.md#tx-sender-nonce-index-enabled) option. If
+the index is disabled, this method returns `null` for mined transactions but still checks the
+transaction pool for pending transactions.
+
+:::
+
+#### Parameters
+
+- `address`: _string_ - 20-byte sender address
+
+- `nonce`: _string_ - hexadecimal integer representing the transaction nonce
+
+#### Returns
+
+`result`: _object_ - [transaction object](objects.md#transaction-object), or `null` if the
+transaction is not found. Pending transactions include `null` values for `blockHash`,
+`blockNumber`, and `transactionIndex`.
+
+<Tabs>
+
+<TabItem value="curl HTTP" label="curl HTTP" default>
+
+```bash
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionBySenderAndNonce","params":["0xfe3b557e8fb62b89f4916b721be55ceb828dbd73","0x1"],"id":53}' http://127.0.0.1:8545/ -H "Content-Type: application/json"
+```
+
+</TabItem>
+
+<TabItem value="wscat WS" label="wscat WS">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "eth_getTransactionBySenderAndNonce",
+  "params": [
+    "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
+    "0x1"
+  ],
+  "id": 53
+}
+```
+
+</TabItem>
+
+<TabItem value="JSON result" label="JSON result">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 53,
+  "result": {
+    "blockHash": "0x510efccf44a192e6e34bcb439a1947e24b86244280762cbb006858c237093fda",
+    "blockNumber": "0x422",
+    "blockTimestamp": "0x561bc2e0",
+    "chainId": 2018,
+    "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
+    "gas": "0x5208",
+    "gasPrice": "0x3b9aca00",
+    "hash": "0xa52be92809541220ee0aaaede6047d9a6c5d0cd96a517c854d944ee70a0ebb44",
+    "input": "0x",
+    "nonce": "0x1",
+    "to": "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+    "transactionIndex": "0x0",
+    "value": "0x4e1003b28d9280000",
+    "v": "0xfe7",
+    "r": "0x84caf09aefbd5e539295acc67217563438a4efb224879b6855f56857fa2037d3",
+    "s": "0x5e863be3829812c81439f0ae9d8ecb832b531d651fb234c848d1bf45e62be8b9"
+  }
+}
+```
+
+</TabItem>
+
+</Tabs>
+
 ### `eth_getTransactionCount`
 
 Returns the number of transactions sent from a specified address. Use the `pending` tag to get the next account nonce not used by any pending transactions.

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -5114,7 +5114,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{transaction
 Returns transaction information for the specified sender address and nonce.
 
 :::note
-To return mined transactions, this method requires the sender and nonce index.
+To return transactions included in blocks, this method requires the sender and nonce index.
 The index is enabled by default; you can disable it using
 [`--tx-sender-nonce-index-enabled`](../cli/options.md#tx-sender-nonce-index-enabled).
 If the index is disabled, this method only returns information for pending transactions.

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -5111,16 +5111,14 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{transaction
 
 ### `eth_getTransactionBySenderAndNonce`
 
-Returns transaction information for the given sender address and nonce.
+Returns transaction information for the specified sender address and nonce.
 
 :::note
-
-This method requires the sender and nonce index to look up mined transactions. The index is
-enabled by default. You can disable it using the
-[`--tx-sender-nonce-index-enabled`](../cli/options.md#tx-sender-nonce-index-enabled) option. If
-the index is disabled, this method returns `null` for mined transactions but still checks the
+To return mined transactions, this method requires the sender and nonce index.
+The index is enabled by default; you can disable it using
+[`--tx-sender-nonce-index-enabled`](../cli/options.md#tx-sender-nonce-index-enabled).
+If the index is disabled, this method returns `null` for mined transactions but still checks the
 transaction pool for pending transactions.
-
 :::
 
 #### Parameters
@@ -5131,9 +5129,7 @@ transaction pool for pending transactions.
 
 #### Returns
 
-`result`: _object_ - [transaction object](objects.md#transaction-object), or `null` if the
-transaction is not found. Pending transactions include `null` values for `blockHash`,
-`blockNumber`, and `transactionIndex`.
+`result`: _object_ - [transaction object](objects.md#transaction-object), or `null` when there is no transaction
 
 <Tabs>
 

--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -5117,8 +5117,7 @@ Returns transaction information for the specified sender address and nonce.
 To return mined transactions, this method requires the sender and nonce index.
 The index is enabled by default; you can disable it using
 [`--tx-sender-nonce-index-enabled`](../cli/options.md#tx-sender-nonce-index-enabled).
-If the index is disabled, this method returns `null` for mined transactions but still checks the
-transaction pool for pending transactions.
+If the index is disabled, this method only returns information for pending transactions.
 :::
 
 #### Parameters

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -7592,6 +7592,56 @@ content if the save and restore functionality is enabled using
 The file is created on shutdown and reloaded during startup.
 The default file name is `txpool.dump` in the [data directory](#data-path).
 
+### `tx-sender-nonce-index-enabled`
+
+<Tabs>
+
+<TabItem value="Syntax" label="Syntax" default>
+
+```bash
+--tx-sender-nonce-index-enabled[=<true|false>]
+```
+
+</TabItem>
+
+<TabItem value="Example" label="Example">
+
+```bash
+--tx-sender-nonce-index-enabled=false
+```
+
+</TabItem>
+
+<TabItem value="Environment variable" label="Environment variable">
+
+```bash
+BESU_TX_SENDER_NONCE_INDEX_ENABLED=false
+```
+
+</TabItem>
+
+<TabItem value="Configuration file" label="Configuration file">
+
+```bash
+tx-sender-nonce-index-enabled=false
+```
+
+</TabItem>
+
+</Tabs>
+
+Enables or disables the sender and nonce index, which maps each sender address and nonce to a
+transaction hash. This index is required for
+[`eth_getTransactionBySenderAndNonce`](../../reference/api/index.md#eth_gettransactionbysenderandnonce)
+to return mined transactions. If disabled, `eth_getTransactionBySenderAndNonce` returns `null` for
+mined transactions but still checks the transaction pool for pending transactions.
+
+On mainnet, the index adds approximately 60 bytes per transaction and can reach 150 GB or more on
+a full node. Existing nodes that upgrade without resyncing will not have index entries for
+pre-upgrade transactions.
+
+The default is `true`.
+
 ### `version`
 
 <Tabs>

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -7630,17 +7630,20 @@ tx-sender-nonce-index-enabled=false
 
 </Tabs>
 
-Enables or disables the sender and nonce index, which maps each sender address and nonce to a
-transaction hash. This index is required for
+Enables or disables the sender and nonce index, which maps each sender address and nonce to a transaction hash.
+This index is required for
 [`eth_getTransactionBySenderAndNonce`](../../reference/api/index.md#eth_gettransactionbysenderandnonce)
-to return mined transactions. If disabled, `eth_getTransactionBySenderAndNonce` returns `null` for
-mined transactions but still checks the transaction pool for pending transactions.
-
-On mainnet, the index adds approximately 60 bytes per transaction and can reach 150 GB or more on
-a full node. Existing nodes that upgrade without resyncing will not have index entries for
-pre-upgrade transactions.
-
+to return mined transactions.
 The default is `true`.
+
+:::note Storage impact
+The index adds approximately 60 bytes per transaction.
+If you upgrade Besu to enable this index without resyncing, the index is only populated for blocks processed after the upgrade.
+Resyncing will index the full available transaction history.
+
+Disabling this option for [archive nodes](../../concepts/node-sync.md#archive-nodes) avoids the extra 
+storage cost in the case of a resync.
+:::
 
 ### `version`
 

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -7633,7 +7633,7 @@ tx-sender-nonce-index-enabled=false
 Enables or disables the sender and nonce index, which maps each sender address and nonce to a transaction hash.
 This index is required for
 [`eth_getTransactionBySenderAndNonce`](../../reference/api/index.md#eth_gettransactionbysenderandnonce)
-to return mined transactions.
+to return transactions included in blocks.
 The default is `true`.
 
 :::note Storage impact


### PR DESCRIPTION
## Description

Documents the new `eth_getTransactionBySenderAndNonce` JSON-RPC method and the accompanying `--tx-sender-nonce-index-enabled` CLI option.

## Related issue(s)

Fixes #2019

## Preview

<!-- Provide a PR preview link to the page(s) changed. -->

https://besu-docs-da4h2to16-hyperledger.vercel.app/public-networks/reference/api#eth_gettransactionbysenderandnonce