### PR TITLE
Block param optional for state-reading methods

### DIFF
--- a/docs/public-networks/reference/api/index.md
+++ b/docs/public-networks/reference/api/index.md
@@ -3259,9 +3259,10 @@ Returns the account balance of the specified address.
 
 - `address`: _string_ - 20-byte account address from which to retrieve the balance
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block
   number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
-  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
   :::note
   `pending` returns the same value as `latest`.
@@ -4046,9 +4047,10 @@ Returns the code of the smart contract at the specified address. Besu stores com
 
 - `address`: _string_ - 20-byte contract address
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block number,
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block number,
   block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as
-  described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
   :::note
   `pending` returns the same value as `latest`.
@@ -4494,9 +4496,10 @@ The API allows IoT devices or mobile apps which are unable to run light clients 
 
 - `keys`: _array_ of _strings_ - list of 32-byte storage keys to generate proofs for
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block
   number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
-  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
   :::note
   `pending` returns the same value as `latest`.
@@ -4599,9 +4602,10 @@ Returns the value of a storage position at a specified address.
 
 - `index`: _string_ - integer index of the storage position
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block
   number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
-  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
   :::note
   `pending` returns the same value as `latest`.
@@ -4695,9 +4699,10 @@ This is a batched version of [`eth_getStorageAt`](#eth_getstorageat).
   and each value is an array of storage slot keys (as 32-byte hex strings).
   The maximum total number of storage slots across all addresses is 1024.
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block number,
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block number,
   block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or
-  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+  `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
   :::note
   `pending` returns the same value as `latest`.
@@ -5210,7 +5215,8 @@ Returns the number of transactions sent from a specified address. Use the `pendi
 
 - `address`: _string_ - 20-byte account address
 
-- `blockNumber` or `blockHash`: _string_ - hexadecimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter)
+- `blockNumber` or `blockHash`: _string_ - (optional) hexadecimal integer representing a block number, block hash, or one of the string tags `latest`, `earliest`, `pending`, `finalized`, or `safe`, as described in [block parameter](../../how-to/use-besu-api/json-rpc.md#block-parameter).
+  The default is `latest`.
 
 #### Returns
 


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

Document that the block parameter is optional (defaulting to `latest`) for the six state-reading methods:

- `eth_getBalance`
- `eth_getCode`
- `eth_getStorageAt`
- `eth_getTransactionCount`
- `eth_getProof`
- `eth_getStorageValues`

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #2029 

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-dzo19w0w4-hyperledger.vercel.app/public-networks/reference/api#eth_getbalance
