### PR TITLE
fix: document zero value behavior for api-gas-price-blocks

### DIFF
--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -95,11 +95,11 @@ Number of blocks back from the head block to examine for
 [`eth_maxPriorityFeePerGas`](../api/index.md#eth_maxpriorityfeepergas).
 The default is `100`.
 
-Set to `0` to return the lower-bound value (next block base fee or configured minimum
+Set to `0` to return the lower-bound value (next block's base fee or configured minimum
 gas price) without sampling any historical blocks.
 
 :::note
-In earlier Besu versions, setting `api-gas-price-blocks=0` was incorrectly treated as
+In Besu 26.6.1 and earlier, setting `api-gas-price-blocks=0` was incorrectly treated as
 `1`, causing Besu to sample one block.
 If you relied on that behavior, set `--api-gas-price-blocks=1` instead.
 :::

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -99,7 +99,7 @@ Set to `0` to return the lower-bound value (next block's base fee or configured 
 gas price) without sampling any historical blocks.
 
 :::note
-In Besu 26.6.1 and earlier, setting `api-gas-price-blocks=0` was incorrectly treated as
+In Besu 26.6.1 and earlier, setting `--api-gas-price-blocks=0` was incorrectly treated as
 `1`, causing Besu to sample one block.
 If you relied on that behavior, set `--api-gas-price-blocks=1` instead.
 :::

--- a/docs/public-networks/reference/cli/options.md
+++ b/docs/public-networks/reference/cli/options.md
@@ -90,7 +90,19 @@ api-gas-price-blocks=50
 
 </Tabs>
 
-Number of blocks back from the head block to examine for [`eth_gasPrice`](../api/index.md#eth_gasprice). The default is `100`.
+Number of blocks back from the head block to examine for
+[`eth_gasPrice`](../api/index.md#eth_gasprice) and
+[`eth_maxPriorityFeePerGas`](../api/index.md#eth_maxpriorityfeepergas).
+The default is `100`.
+
+Set to `0` to return the lower-bound value (next block base fee or configured minimum
+gas price) without sampling any historical blocks.
+
+:::note
+In earlier Besu versions, setting `api-gas-price-blocks=0` was incorrectly treated as
+`1`, causing Besu to sample one block.
+If you relied on that behavior, set `--api-gas-price-blocks=1` instead.
+:::
 
 ### `api-gas-price-max`
 


### PR DESCRIPTION
## Description

Update the `api-gas-price-blocks` reference entry to document the corrected behavior
when set to `0`, and add an upgrader note for users who relied on the previous behavior.

Changes:
- Extend the description to include `eth_maxPriorityFeePerGas` alongside `eth_gasPrice`
- Document that `0` returns the lower-bound value without sampling historical blocks
- Add a `:::note` admonition advising upgraders who relied on the old (incorrect) `0 = 1` behavior to switch to `--api-gas-price-blocks=1`

## Related issue(s)

Fixes #2058

## Preview

https://besu-docs-git-fork-bgravenorst-docs-fix-api-af57b0-hyperledger.vercel.app/public-networks/reference/cli/options#api-gas-price-blocks