### PR TITLE
Clarify `engine-rpc-enabled` default

### DIFF
--- a/docs/public-networks/how-to/configure-besu/index.md
+++ b/docs/public-networks/how-to/configure-besu/index.md
@@ -88,7 +88,7 @@ For example, extending the default configuration using the [staker profile](prof
 |---------------------------|--------------------|------------------------------------------|
 |[`discovery-enabled`](../../reference/options.md#discovery-enabled)|`true`|Besu assumes the node will automatically discover other Ethereum nodes using P2P.|
 |[`p2p-enabled`](../../reference/options.md#p2p-enabled)|`true`|Besu assumes the node will connect P2P.|
-|[`engine-rpc-enabled`](../../reference/options.md#engine-rpc-enabled)|`true`|Besu assumes the Engine API will be required to communicate with the consensus layer.|
+|[`engine-rpc-enabled`](../../reference/options.md#engine-rpc-enabled)|`true`|The option's default value is `false`, but Besu enables the Engine API automatically on post-Merge networks. Using the default network (Mainnet), the Engine API is enabled.|
 
 ### Storage
 

--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -953,9 +953,11 @@ engine-rpc-enabled=true
 
 </Tabs>
 
-Enables or disables the [Engine API](engine-api.md). 
+Enables or disables the [Engine API](engine-api.md).
 
 The default is `false`.
+On post-Merge networks (including Mainnet and public testnets), Besu
+enables the Engine API automatically whether or not you set this option.
 
 ---
 


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

Clarify conflicting defaults for `engine-rpc-enabled`.

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-9eqdlu90k-hyperledger.vercel.app/public-networks/how-to/configure-besu#peering
