### PR TITLE
Deprecate `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled`

### DIFF
--- a/docs/public-networks/concepts/data-storage-formats.md
+++ b/docs/public-networks/concepts/data-storage-formats.md
@@ -68,8 +68,6 @@ Use the following estimates as a reference point, not fixed minimum requirements
 
 The Bonsai snap sync estimate is based on May 2026 burn-in results for the Besu 26.5.0
 release cycle on AWS `m8g.2xlarge` instances.
-By default, snap sync prunes historical block data for PoW blocks, retaining only the headers and the genesis block.
-Downloading full PoW blocks (by setting [`--snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false`](../reference/options.md#snapsync-synchronizer-pre-checkpoint-headers-only-enabled)) increases disk usage.
 
 Forest mode uses significantly more memory than Bonsai, and we do not recommend using it on Mainnet.
 

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -76,15 +76,9 @@ Snap sync is the default sync mode for all named [networks](../reference/options
 except `dev`.
 You can enable snap sync using [`--sync-mode=SNAP`](../reference/options.md#sync-mode).
 You need Besu version 22.4.0 or later to use snap sync.
-By default, [Snap sync prunes historical block data](../how-to/pre-merge-history-expiry.md) for
+[Snap sync prunes historical block data](../how-to/pre-merge-history-expiry.md) for
 [pre-merge](https://ethereum.org/en/roadmap/merge/) PoW blocks, retaining only the
 headers and the genesis block.
-
-:::note
-To download the full PoW block history, set
-[`--snapsync-synchronizer-pre-checkpoint-headers-only-enabled`](../reference/options.md#snapsync-synchronizer-pre-checkpoint-headers-only-enabled)
-to `false`. However, this will increase the sync time and disk space usage.
-:::
 
 Instead of downloading the [state trie](data-storage-formats.md) node by node, snap
 sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.

--- a/docs/public-networks/concepts/node-sync.md
+++ b/docs/public-networks/concepts/node-sync.md
@@ -76,9 +76,11 @@ Snap sync is the default sync mode for all named [networks](../reference/options
 except `dev`.
 You can enable snap sync using [`--sync-mode=SNAP`](../reference/options.md#sync-mode).
 You need Besu version 22.4.0 or later to use snap sync.
-[Snap sync prunes historical block data](../how-to/pre-merge-history-expiry.md) for
-[pre-merge](https://ethereum.org/en/roadmap/merge/) PoW blocks, retaining only the
-headers and the genesis block.
+When a [checkpoint](../reference/genesis-items.md#checkpoint-configuration) is defined, which the
+default Mainnet genesis file specifies, snap sync
+[doesn't download historical block data](../how-to/pre-merge-history-expiry.md) for
+[pre-merge](https://ethereum.org/en/roadmap/merge/) PoW blocks, downloading only the headers and
+the genesis block.
 
 Instead of downloading the [state trie](data-storage-formats.md) node by node, snap
 sync downloads as many leaves of the trie as possible, and reconstructs the trie locally.

--- a/docs/public-networks/how-to/pre-merge-history-expiry.md
+++ b/docs/public-networks/how-to/pre-merge-history-expiry.md
@@ -7,7 +7,7 @@ description: Reduce the size of your database by removing pre-merge blocks from 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Node operators using [Snap sync](../concepts/node-sync.md#snap-synchronization) can significantly reduce
+Node operators using [snap sync](../concepts/node-sync.md#snap-synchronization) can significantly reduce
 disk usage by removing [pre-merge](https://ethereum.org/en/roadmap/merge/) Proof of Work (PoW)
 block data from the local database.
 
@@ -17,16 +17,16 @@ the genesis block.
 :::warning
 
 Besu does not currently provide a way to import pre-merge block data after pruning.
-If you need to restore the full pre-merge history, you can revert to the former Snap sync behaviour and download
-all blocks from peers by setting
-[`--snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false`](../reference/options.md#snapsync-synchronizer-pre-checkpoint-headers-only-enabled).
+If you need to restore the full pre-merge history, delete your database and use
+[full sync](../concepts/node-sync.md#full-synchronization) instead, which downloads and retains
+all blocks from peers.
 
 :::
 
 Besu provides multiple options to prune the historical blockchain data:
 - [Offline pruning](#offline-pruning) to prune data on a stopped Besu instance.
 - [Online pruning](#online-pruning) to prune data on a running Besu instance.
-- [Sync Besu](#sync-without-pre-merge-blocks) using Snap sync, which by default prunes the historical
+- [Sync Besu](#sync-without-pre-merge-blocks) using snap sync, which prunes the historical
     blockchain data.
 
 ## Offline pruning
@@ -81,8 +81,8 @@ when complete.
 ## Sync without pre-merge blocks
 
 This option has the most downtime but reclaims the most disk space.
-Delete your database and by default, syncing a Besu node using [`SNAP` sync (`--sync-mode=SNAP`)](../reference/options.md#sync-mode)
-will prune pre-merge blocks and only retain their headers.
+Delete your database and sync a Besu node using [`SNAP` sync (`--sync-mode=SNAP`)](../reference/options.md#sync-mode),
+which prunes pre-merge blocks and only retains their headers.
 
 If you're a solo staker, consider using [RocketPool's rescue node](https://rescuenode.com/docs/about)
 to minimize downtime.

--- a/docs/public-networks/how-to/pre-merge-history-expiry.md
+++ b/docs/public-networks/how-to/pre-merge-history-expiry.md
@@ -7,27 +7,29 @@ description: Reduce the size of your database by removing pre-merge blocks from 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Node operators using [snap sync](../concepts/node-sync.md#snap-synchronization) can significantly reduce
-disk usage by removing [pre-merge](https://ethereum.org/en/roadmap/merge/) Proof of Work (PoW)
-block data from the local database.
+Node operators can significantly reduce disk usage related to
+[pre-merge](https://ethereum.org/en/roadmap/merge/) Proof of Work (PoW) block data by pruning it
+from an existing database, or by using [snap sync](../concepts/node-sync.md#snap-synchronization)
+with a [checkpoint](../reference/genesis-items.md#checkpoint-configuration) defined to avoid
+downloading it in the first place.
 
-Besu can prune all pre-merge block bodies and associated transaction receipts, leaving only headers and
-the genesis block.
+Pruning removes all pre-merge block bodies and associated transaction receipts from the database,
+leaving only headers and the genesis block.
 
 :::warning
 
 Besu does not currently provide a way to import pre-merge block data after pruning.
 If you need to restore the full pre-merge history, delete your database and use
-[full sync](../concepts/node-sync.md#full-synchronization) instead, which downloads and retains
-all blocks from peers.
+[full sync](../concepts/node-sync.md#full-synchronization), or snap sync with a genesis file that doesn't 
+specify a checkpoint.
 
 :::
 
-Besu provides multiple options to prune the historical blockchain data:
+Besu provides multiple options to reduce historical blockchain data:
 - [Offline pruning](#offline-pruning) to prune data on a stopped Besu instance.
 - [Online pruning](#online-pruning) to prune data on a running Besu instance.
-- [Sync Besu](#sync-without-pre-merge-blocks) using snap sync, which prunes the historical
-    blockchain data.
+- [Sync Besu](#sync-without-pre-merge-blocks) using snap sync, which avoids downloading pre-merge
+    block bodies and transaction receipts.
 
 ## Offline pruning
 
@@ -81,8 +83,10 @@ when complete.
 ## Sync without pre-merge blocks
 
 This option has the most downtime but reclaims the most disk space.
-Delete your database and sync a Besu node using [`SNAP` sync (`--sync-mode=SNAP`)](../reference/options.md#sync-mode),
-which prunes pre-merge blocks and only retains their headers.
+Delete your database and sync a Besu node using [`SNAP` sync (`--sync-mode=SNAP`)](../reference/options.md#sync-mode).
+When a [checkpoint](../reference/genesis-items.md#checkpoint-configuration) is defined, which the
+default Mainnet genesis file specifies, snap sync doesn't download pre-merge block bodies or
+transaction receipts, and only downloads headers.
 
 If you're a solo staker, consider using [RocketPool's rescue node](https://rescuenode.com/docs/about)
 to minimize downtime.

--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -5879,12 +5879,17 @@ snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false
 
 </Tabs>
 
-If set to `false`, [snap sync](../concepts/node-sync.md#snap-synchronization) downloads full pre-merge Proof of Work (PoW) historical blocks
-instead of headers only, allowing full historical data to be retained. 
+:::warning Deprecated
 
-The default is `true`.
+The `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` option is deprecated and will be
+removed in a future release.
+Besu recognizes this option, but it has no effect.
+[Snap sync](../concepts/node-sync.md#snap-synchronization) always prunes pre-merge Proof of Work
+(PoW) historical blocks, retaining only headers and the genesis block.
+To retain full pre-merge block history, use
+[full sync](../concepts/node-sync.md#full-synchronization) instead.
 
-Setting this option to `false` increases sync time and disk space usage.
+:::
 
 ---
 

--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -5925,10 +5925,12 @@ snapsync-synchronizer-pre-checkpoint-headers-only-enabled=false
 The `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` option is deprecated and will be
 removed in a future release.
 Besu recognizes this option, but it has no effect.
-[Snap sync](../concepts/node-sync.md#snap-synchronization) always prunes pre-merge Proof of Work
-(PoW) historical blocks, retaining only headers and the genesis block.
-To retain full pre-merge block history, use
-[full sync](../concepts/node-sync.md#full-synchronization) instead.
+When a [checkpoint](genesis-items.md#checkpoint-configuration) is defined, which the default
+Mainnet genesis file specifies, [snap sync](../concepts/node-sync.md#snap-synchronization) doesn't
+download pre-merge Proof of Work (PoW) block bodies or transaction receipts, and only downloads
+headers.
+To retain full pre-merge block history, use [full sync](../concepts/node-sync.md#full-synchronization),
+or sync using a genesis file that doesn't specify a checkpoint.
 
 :::
 


### PR DESCRIPTION
## Description

<!-- Briefly explain what changed and why. -->

Mark `--snapsync-synchronizer-pre-checkpoint-headers-only-enabled` option as deprecated, and update wording around snap sync behavior where applicable.

## Related issue(s)

<!-- Use "Fixes #123" or "Relates to #123". Leave "N/A" if there is no issue. -->

Fixes #2085

## Preview

<!-- Provide a PR preview link to the page(s) changed. {Example: https://besu-docs-git-100-branch-hyperledger.vercel.app} -->

https://besu-docs-git-fork-alexandratran-2085-deprec-31433a-hyperledger.vercel.app/public-networks/reference/options#snapsync-synchronizer-pre-checkpoint-headers-only-enabled