### PR TITLE
fix: correct debug_traceTransaction structLog field from exceptionalHaltReasons to error [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/docs/public-networks/reference/api/debug/trace.md
+++ b/docs/public-networks/reference/api/debug/trace.md
@@ -256,7 +256,7 @@ Reruns the transaction with the same state as when the transaction executed.
 
     - `depth`: _integer_ - Execution depth.
 
-    - `exceptionalHaltReasons`: _array_ - One or more strings representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
+    - `error`: _string_ - A string representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
 
     - `stack`: _array of 32 byte arrays_ - EVM execution stack before executing current operation.
 
@@ -398,7 +398,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
     - `depth`: _integer_ - Execution depth.
 
-    - `exceptionalHaltReasons`: _array_ - One or more strings representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
+    - `error`: _string_ - A string representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
 
     - `stack`: _array of 32 byte arrays_ - EVM execution stack before executing current operation.
 
@@ -531,7 +531,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
     - `depth`: _integer_ - Execution depth.
 
-    - `exceptionalHaltReasons`: _array_ - One or more strings representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
+    - `error`: _string_ - A string representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
 
     - `stack`: _array of 32 byte arrays_ - EVM execution stack before executing current operation.
 
@@ -672,7 +672,7 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
     - `depth`: _integer_ - Execution depth.
 
-    - `exceptionalHaltReasons`: _array_ - One or more strings representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
+    - `error`: _string_ - A string representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
 
     - `stack`: _array of 32 byte arrays_ - EVM execution stack before executing current operation.
 
@@ -878,7 +878,7 @@ temporary state changes without affecting the actual blockchain state.
 
     - `depth`: _integer_ - Execution depth.
 
-    - `exceptionalHaltReasons`: _array_ - One or more strings representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
+    - `error`: _string_ - A string representing an error condition causing the EVM execution to terminate, such as running out of gas or attempting to execute an unknown instruction.
 
     - `stack`: _array of 32 byte arrays_ - EVM execution stack before executing current operation.
 


### PR DESCRIPTION
## Description

Fixes hyperledger/besu#11040

The `debug_traceTransaction` documentation describes `exceptionalHaltReasons` as an array field in the structLog, but the actual implementation ([StructLogWithError.java](https://github.com/hyperledger/besu/blob/main/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogWithError.java#L23-L37)) serializes the halt reason as a singular `error` string via `@JsonGetter("error")` from `ExceptionalHaltReason::name`.

### Changes

Updated `docs/public-networks/reference/api/debug/trace.md` (5 occurrences):
- Renamed `exceptionalHaltReasons` field to `error`
- Changed type from `_array_` to `_string_`
- Updated description: "One or more strings..." → "A string..."

### Verification

Reproduction from the issue shows the actual response:

```json
{"result": {"gas": 22000, "failed": true, "returnValue": "", "structLogs": [
  {"pc": 2, "op": "SLOAD", "gas": 997, "gasCost": 2100, "depth": 1, "error": "INSUFFICIENT_GAS"}
]}}
```

No `exceptionalHaltReasons` key exists in the trace response.