### PR TITLE
DOC-2099: Update debug trace returnValue and structLogs

### DIFF
--- a/docs/public-networks/reference/api/debug/trace.md
+++ b/docs/public-networks/reference/api/debug/trace.md
@@ -240,9 +240,12 @@ Reruns the transaction with the same state as when the transaction executed.
 
   - `failed`: _boolean_ - True if transaction failed, otherwise, false.
 
-  - `returnValue`: _string_ - Bytes returned from transaction execution (without a `0x` prefix).
+  - `returnValue`: _string_ - Bytes returned from transaction execution, as a hex
+    string with a `0x` prefix.
+    Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
+    Empty when the executed code is empty (for example, a plain value transfer).
 
     <Fields>
 
@@ -323,7 +326,7 @@ curl -X POST http://127.0.0.1:8545/ \
   "result": {
     "gas": 21000,
     "failed": false,
-    "returnValue": "",
+    "returnValue": "0x",
     "structLogs": [
       {
         "pc": 100,
@@ -382,9 +385,12 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `failed`: _boolean_ - True if transaction failed, otherwise, false.
 
-  - `returnValue`: _string_ - Bytes returned from transaction execution (without a `0x` prefix).
+  - `returnValue`: _string_ - Bytes returned from transaction execution, as a hex
+    string with a `0x` prefix.
+    Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
+    Empty when the executed code is empty (for example, a plain value transfer).
 
     <Fields>
 
@@ -457,17 +463,8 @@ curl -X POST http://127.0.0.1:8545/ \
   "result": {
     "gas": 21000,
     "failed": false,
-    "returnValue": "",
-    "structLogs": [
-      {
-        "pc": 0,
-        "op": "STOP",
-        "gas": 0,
-        "gasCost": 0,
-        "depth": 1,
-        "stack": []
-      }
-    ]
+    "returnValue": "0x",
+    "structLogs": []
   }
 }
 ```
@@ -515,9 +512,12 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `failed`: _boolean_ - True if transaction failed, otherwise, false.
 
-  - `returnValue`: _string_ - Bytes returned from transaction execution (without a `0x` prefix).
+  - `returnValue`: _string_ - Bytes returned from transaction execution, as a hex
+    string with a `0x` prefix.
+    Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
+    Empty when the executed code is empty (for example, a plain value transfer).
 
     <Fields>
 
@@ -591,17 +591,8 @@ curl -X POST http://127.0.0.1:8545/ \
     {
       "gas": 21000,
       "failed": false,
-      "returnValue": "",
-      "structLogs": [
-        {
-          "pc": 0,
-          "op": "STOP",
-          "gas": 0,
-          "gasCost": 0,
-          "depth": 1,
-          "stack": []
-        }
-      ]
+      "returnValue": "0x",
+      "structLogs": []
     }
   ]
 }
@@ -656,9 +647,12 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
 
   - `failed`: _boolean_ - True if transaction failed, otherwise, false.
 
-  - `returnValue`: _string_ - Bytes returned from transaction execution (without a `0x` prefix).
+  - `returnValue`: _string_ - Bytes returned from transaction execution, as a hex
+    string with a `0x` prefix.
+    Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
+    Empty when the executed code is empty (for example, a plain value transfer).
 
     <Fields>
 
@@ -738,17 +732,8 @@ curl -X POST http://127.0.0.1:8545/ \
     {
       "gas": 21000,
       "failed": false,
-      "returnValue": "",
-      "structLogs": [
-        {
-          "pc": 0,
-          "op": "STOP",
-          "gas": 0,
-          "gasCost": 0,
-          "depth": 1,
-          "stack": []
-        }
-      ]
+      "returnValue": "0x",
+      "structLogs": []
     }
   ]
 }
@@ -862,9 +847,12 @@ temporary state changes without affecting the actual blockchain state.
 
   - `failed`: _boolean_ - True if transaction failed, otherwise, false.
 
-  - `returnValue`: _string_ - Bytes returned from transaction execution (without a `0x` prefix).
+  - `returnValue`: _string_ - Bytes returned from transaction execution, as a hex
+    string with a `0x` prefix.
+    Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
+    Empty when the executed code is empty (for example, a plain value transfer).
 
     <Fields>
 
@@ -950,16 +938,8 @@ curl -X POST http://127.0.0.1:8545/ \
     {
       "gas": 21000,
       "failed": false,
-      "returnValue": "",
-      "structLogs": [
-        {
-          "pc": 0,
-          "op": "STOP",
-          "gas": 0,
-          "gasCost": 0,
-          "depth": 1
-        }
-      ]
+      "returnValue": "0x",
+      "structLogs": []
     }
   ]
 }

--- a/docs/public-networks/reference/api/debug/trace.md
+++ b/docs/public-networks/reference/api/debug/trace.md
@@ -245,7 +245,8 @@ Reruns the transaction with the same state as when the transaction executed.
     Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
-    Empty when the executed code is empty (for example, a plain value transfer).
+    Empty when the executed code is empty (for example, a plain value transfer
+    between two externally owned accounts (EOAs)).
 
     <Fields>
 
@@ -390,7 +391,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
     Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
-    Empty when the executed code is empty (for example, a plain value transfer).
+    Empty when the executed code is empty (for example, a plain value transfer
+    between two externally owned accounts (EOAs)).
 
     <Fields>
 
@@ -517,7 +519,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
     Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
-    Empty when the executed code is empty (for example, a plain value transfer).
+    Empty when the executed code is empty (for example, a plain value transfer
+    between two externally owned accounts (EOAs)).
 
     <Fields>
 
@@ -652,7 +655,8 @@ Returns full trace of all invoked opcodes of all transactions included in the bl
     Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
-    Empty when the executed code is empty (for example, a plain value transfer).
+    Empty when the executed code is empty (for example, a plain value transfer
+    between two externally owned accounts (EOAs)).
 
     <Fields>
 
@@ -852,7 +856,8 @@ temporary state changes without affecting the actual blockchain state.
     Empty output is `"0x"`.
 
   - `structLogs`: _array_ - Array of structured log objects.
-    Empty when the executed code is empty (for example, a plain value transfer).
+    Empty when the executed code is empty (for example, a plain value transfer
+    between two externally owned accounts (EOAs)).
 
     <Fields>
 


### PR DESCRIPTION
## Description

Updates the DEBUG opcode-tracer reference to match [besu-eth/besu#10972](https://github.com/besu-eth/besu/pull/10972).

Examples that showed a 21000-gas transfer with a trailing `STOP` now use `"returnValue": "0x"` and `"structLogs": []`. The `debug_traceTransaction` example keeps a contract-call `structLogs` entry (a real `STATICCALL`, not the synthetic `STOP`).

## Related issue(s)

Fixes #2099

## Preview

https://besu-docs-git-fork-bgravenorst-doc-2099-hyperledger.vercel.app/public-networks/reference/api/debug/trace
