### PR TITLE
DOC-2102: Remove min-block-occupancy-ratio CLI option reference

### DIFF
--- a/docs/public-networks/reference/options.md
+++ b/docs/public-networks/reference/options.md
@@ -2528,48 +2528,6 @@ The job name when in `push` mode. The default is `besu-client`.
 
 ---
 
-## `min-block-occupancy-ratio`
-
-<Tabs>
-
-<TabItem value="Command line example">
-
-```bash
---min-block-occupancy-ratio=0.5
-```
-
-</TabItem>
-
-<TabItem value="Environment variable example">
-
-```bash
-BESU_MIN_BLOCK_OCCUPANCY_RATIO=0.5
-```
-
-</TabItem>
-
-<TabItem value="Config file example">
-
-```bash
-min-block-occupancy-ratio="0.5"
-```
-
-</TabItem>
-
-</Tabs>
-
-Minimum occupancy ratio for a mined block if the transaction pool is not empty. When filling a block during mining, the occupancy ratio indicates the threshold at which the node stops waiting for smaller transactions to fill the remaining space. The default is 0.8.
-
-:::warning Deprecated
-
-The `--min-block-occupancy-ratio` option is deprecated and will be removed in a
-future release.
-Besu recognizes this option, but it has no effect.
-
-:::
-
----
-
 ## `min-gas-price`
 
 <Tabs>


### PR DESCRIPTION
## Description

Removes the `--min-block-occupancy-ratio` entry from the CLI options reference.
Besu removed this option in [besu-eth/besu#11017](https://github.com/besu-eth/besu/pull/11017).
It had been a silent no-op since 26.4.0 and was PoW-related with no replacement.

## Related issue(s)

Fixes #2102

## Preview

https://besu-docs-git-fork-bgravenorst-doc-2102-hyperledger.vercel.app/public-networks/reference/options

